### PR TITLE
Fix the extension in web.config for standalone apps

### DIFF
--- a/src/Publish/Microsoft.NET.Sdk.Publish.Targets/TransformTargets/Microsoft.NET.Sdk.Publish.TransformFiles.targets
+++ b/src/Publish/Microsoft.NET.Sdk.Publish.Targets/TransformTargets/Microsoft.NET.Sdk.Publish.TransformFiles.targets
@@ -22,13 +22,25 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </PropertyGroup>
 
   <Target Name="_WebConfigTransform">
+
     <PropertyGroup>
       <_IsManagedProject Condition="%(ProjectCapability.Identity) == 'Managed'">true</_IsManagedProject>
       <_IsAspNetCoreProject Condition="%(ProjectCapability.Identity) == 'AspNetCore'">true</_IsAspNetCoreProject>
-      <_IsPortable Condition=" '$(_IsPortable)' == '' And '$(RuntimeIdentifier)' != '' ">false</_IsPortable>
-      <_IsPortable Condition=" '$(_IsPortable)' == '' ">true</_IsPortable>      
+      
+      <_IsPortable Condition=" '$(_IsPortable)' == '' 
+                   And '$(_IsManagedProject)' == 'true' 
+                   And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' 
+                   And '$(RuntimeIdentifier)' != '' ">false</_IsPortable>
+      
+      <_IsPortable Condition=" '$(_IsPortable)' == '' 
+                   And '$(_IsManagedProject)' == 'true' 
+                   And '$(TargetFrameworkIdentifier)' == '.NETFramework' ">false</_IsPortable>
+      
+      <_IsPortable Condition=" '$(_IsPortable)' == ''">true</_IsPortable>
+      
       <_TransformWebConfigForAzure Condition=" '$(WEBSITE_SITE_NAME)' != '' Or '$(DOTNET_CONFIGURE_AZURE)' == 'true' Or '$(DOTNET_CONFIGURE_AZURE)' == '1'">true</_TransformWebConfigForAzure>
     </PropertyGroup>
+    
 
     <TransformWebConfig
         Condition="'$(_IsManagedProject)' == 'true' And '$(_IsAspNetCoreProject)' == 'true'"

--- a/src/Publish/Microsoft.NETCore.Sdk.Publish.Tasks/WebConfigTransform.cs
+++ b/src/Publish/Microsoft.NETCore.Sdk.Publish.Tasks/WebConfigTransform.cs
@@ -59,7 +59,6 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
             var appPath = Path.Combine(".", appName).Replace("/", "\\");
             RemoveLauncherArgs(aspNetCoreElement);
 
-            // Temporary fix to rename the extension from .dll to .exe for standalone apps.
             if (!isPortable)
             {
                 appPath = Path.ChangeExtension(appPath, ".exe");


### PR DESCRIPTION
Identifying the non-portable scenarios and passing the appname.exe in non-portable scenarios.
@abpiskunov @BillHiebert 
