### PR TITLE
Remove items in node_modules and jspm_packages folders from Compile and EmbeddedResource item lists

### DIFF
--- a/src/Web/Microsoft.NET.Sdk.Web.ProjectSystem.Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.targets
+++ b/src/Web/Microsoft.NET.Sdk.Web.ProjectSystem.Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.targets
@@ -39,6 +39,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Globbing patterns to include relevant files to web projects -->
 
   <!-- Core web globbing patterns -->
+
+  <PropertyGroup>
+    <DefaultWebRemoves>wwwroot\**;node_modules\**;jspm_packages\**</DefaultWebRemoves>
+  </PropertyGroup>
+  
   <ItemGroup>
     <Content Include="wwwroot\**">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
@@ -51,8 +56,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     </Content>
     <Content Include="**\web.debug.config" Exclude="wwwroot\**\web.debug.config"/>
     <Content Include="**\web.release.config" Exclude="wwwroot\**\web.release.config"/>
-    <Compile Remove="wwwroot\**\*.cs"/>
-    <EmbeddedResource Remove="wwwroot\**\*.resx"/>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(DisableDefaultWebRemoves)' != 'true'">
+    <Compile Remove="$(DefaultWebRemoves)" />
+    <EmbeddedResource Remove="$(DefaultWebRemoves)" />
   </ItemGroup>
 
   <!-- Publishing configuration files -->


### PR DESCRIPTION
Per discussion in dotnet/sdk#310, it sounds like we want to remove the node and jspm packages folders from the `Compile` and `EmbeddedResource` item lists in the Web Sdk targets.
