### PR TITLE
Removing the call to dotnet restore3 from prepublish target

### DIFF
--- a/src/Publish/Microsoft.NET.Sdk.Publish.Targets/BeforePublishTargets/Microsoft.NET.Sdk.BeforePublish.targets
+++ b/src/Publish/Microsoft.NET.Sdk.Publish.Targets/BeforePublishTargets/Microsoft.NET.Sdk.BeforePublish.targets
@@ -23,12 +23,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
           DependsOnTargets="$(BeforePublishDependsOn)">
 
     <!-- Run the restore for the specific RID for standalone applications -->
-    <PropertyGroup>
+    <!--<PropertyGroup>
       <_IsManagedProject Condition="%(ProjectCapability.Identity) == 'Managed'">true</_IsManagedProject>
-    </PropertyGroup>
+    </PropertyGroup>-->
     
-    <Exec Condition="'$(_IsManagedProject)' == 'true' And '$(RuntimeIdentifier)' != ''"
+    <!-- Running the restore from CLI is not supported because necessary props and taregts will not be imported. 
+         Temporary fix is to add the RuntimeIdentier to the csproj. -->
+    
+    <!--<Exec Condition="'$(_IsManagedProject)' == 'true' And '$(RuntimeIdentifier)' != ''"
           Command="dotnet restore3 $(MSBuildProjectFile) /p:RuntimeIdentifier=$(RuntimeIdentifier);TargetFramework=$(PublishFramework)"
-          WorkingDirectory="$(MSBuildProjectDirectory)" />
+          WorkingDirectory="$(MSBuildProjectDirectory)" />-->
   </Target>
 </Project>


### PR DESCRIPTION
@abpiskunov @BillHiebert 

I am removing the call to restore3 because RID will be added to the csproj.