### PR TITLE
Add <OutputType>Exe</OutputType> to the SDK

### DIFF
--- a/src/Web/Microsoft.NET.Sdk.Web.ProjectSystem.Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.props
+++ b/src/Web/Microsoft.NET.Sdk.Web.ProjectSystem.Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.props
@@ -12,7 +12,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <OutputType Condition='$(OutputType) == '''>Exe</OutputType>
+    <OutputType Condition="$(OutputType) == ''">Exe</OutputType>
     <GlobalExclude>$(GlobalExclude);bin\**;obj\**;node_modules\**;jspm_packages\**;bower_components\**;**\*.user;**\*.*proj;**\*.sln;**\*.vssscc;**\.*\**</GlobalExclude>
     <PreserveCompilationContext Condition="'$(PreserveCompilationContext)' == ''">true</PreserveCompilationContext>
   </PropertyGroup>


### PR DESCRIPTION
All web projects are exe's so default this in the SDK

- Not sure if I need to add a condition field.
- One downside (minor) is that this *does* differ from the defaults of the .NET Core SDK itself but that should be fine...

/cc @mlorbetske @vijayrkn 