### PR TITLE
Adding tests for Full framework

### DIFF
--- a/test/Publish/Microsoft.NET.Sdk.Publish.Tasks.Tests/EndToEnd/ProcessWrapper.cs
+++ b/test/Publish/Microsoft.NET.Sdk.Publish.Tasks.Tests/EndToEnd/ProcessWrapper.cs
@@ -25,7 +25,10 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Tests.EndToEnd
             startInfo.CreateNoWindow = false;
             startInfo.WorkingDirectory = workingDirectory;
             startInfo.FileName = fileName;
-            startInfo.Arguments = arguments;
+            if (!string.IsNullOrEmpty(arguments))
+            {
+                startInfo.Arguments = arguments;
+            }
 
             Process testProcess = Process.Start(startInfo);
             processId = testProcess?.Id;

--- a/test/Publish/Microsoft.NET.Sdk.Publish.Tasks.Tests/Microsoft.NET.Sdk.Publish.Tasks.Tests.csproj
+++ b/test/Publish/Microsoft.NET.Sdk.Publish.Tasks.Tests/Microsoft.NET.Sdk.Publish.Tasks.Tests.csproj
@@ -39,6 +39,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Management" />
+    <Compile Condition="$(EndToEndTestsEnabled) != 'true'" Remove="EndToEnd\*.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Publish\Microsoft.NET.Sdk.Publish.Tasks\Microsoft.NET.Sdk.Publish.Tasks.csproj" />


### PR DESCRIPTION
@mlorbetske @balachir 

Running all the following tests took about 23 min on my dev box. I will look at moving some of these tests out.

Tests covers the following scenarios:
1. empty web - core(netcoreapp1.0 & netcoreapp1.1) & full (net 452, net46, net461, net462)
2. mvc - core(netcoreapp1.0 & netcoreapp1.1) & full (net 452, net46, net461, net462) with no auth & ind auth
3. web api - core(netcoreapp1.0 & netcoreapp1.1) & full (net 452, net46, net461, net462)
