### PR TITLE
Disabling all net462 tests & cleaning up processes

### DIFF
--- a/test/Publish/Microsoft.NET.Sdk.Publish.Tasks.Tests/EndToEnd/FolderPublish.cs
+++ b/test/Publish/Microsoft.NET.Sdk.Publish.Tasks.Tests/EndToEnd/FolderPublish.cs
@@ -129,10 +129,10 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Tests.EndToEnd
         [InlineData("netcoreapp1.0", "Debug", "core", "net461")]
         [InlineData("netcoreapp1.1", "Debug", "core", "net461")]
 
-        [InlineData("netcoreapp1.0", "Release", "core", "net462")]
-        [InlineData("netcoreapp1.1", "Release", "core", "net462")]
-        [InlineData("netcoreapp1.0", "Debug", "core", "net462")]
-        [InlineData("netcoreapp1.1", "Debug", "core", "net462")]
+        //[InlineData("netcoreapp1.0", "Release", "core", "net462")]
+        //[InlineData("netcoreapp1.1", "Release", "core", "net462")]
+        //[InlineData("netcoreapp1.0", "Debug", "core", "net462")]
+        //[InlineData("netcoreapp1.1", "Debug", "core", "net462")]
         public async Task EmptyWebNET(string templateFramework, string configuration, string msBuildType, string targetFramework)
         {
             string projectName = $"{nameof(EmptyWebNET)}_{Path.GetRandomFileName()}";
@@ -169,10 +169,10 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Tests.EndToEnd
         [InlineData("netcoreapp1.0", "Debug", "core", "net461")]
         [InlineData("netcoreapp1.1", "Debug", "core", "net461")]
 
-        [InlineData("netcoreapp1.0", "Release", "core", "net462")]
-        [InlineData("netcoreapp1.1", "Release", "core", "net462")]
-        [InlineData("netcoreapp1.0", "Debug", "core", "net462")]
-        [InlineData("netcoreapp1.1", "Debug", "core", "net462")]
+        //[InlineData("netcoreapp1.0", "Release", "core", "net462")]
+        //[InlineData("netcoreapp1.1", "Release", "core", "net462")]
+        //[InlineData("netcoreapp1.0", "Debug", "core", "net462")]
+        //[InlineData("netcoreapp1.1", "Debug", "core", "net462")]
         public async Task WebAPINET(string templateFramework, string configuration, string msBuildType, string targetFramework)
         {
             string projectName = $"{nameof(WebAPINET)}_{Path.GetRandomFileName()}";
@@ -234,18 +234,18 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Tests.EndToEnd
         [InlineData("netcoreapp1.0", "Debug", "core", "Individual", "true", "net461")]
         [InlineData("netcoreapp1.1", "Debug", "core", "Individual", "true", "net461")]
 
-        [InlineData("netcoreapp1.0", "Release", "core", "none", "false", "net462")]
-        [InlineData("netcoreapp1.1", "Release", "core", "none", "false", "net462")]
-        [InlineData("netcoreapp1.0", "Debug", "core", "none", "false", "net462")]
-        [InlineData("netcoreapp1.1", "Debug", "core", "none", "false", "net462")]
-        [InlineData("netcoreapp1.0", "Release", "core", "Individual", "false", "net462")]
-        [InlineData("netcoreapp1.1", "Release", "core", "Individual", "false", "net462")]
-        [InlineData("netcoreapp1.0", "Debug", "core", "Individual", "false", "net462")]
-        [InlineData("netcoreapp1.1", "Debug", "core", "Individual", "false", "net462")]
-        [InlineData("netcoreapp1.0", "Release", "core", "Individual", "true", "net462")]
-        [InlineData("netcoreapp1.1", "Release", "core", "Individual", "true", "net462")]
-        [InlineData("netcoreapp1.0", "Debug", "core", "Individual", "true", "net462")]
-        [InlineData("netcoreapp1.1", "Debug", "core", "Individual", "true", "net462")]
+        //[InlineData("netcoreapp1.0", "Release", "core", "none", "false", "net462")]
+        //[InlineData("netcoreapp1.1", "Release", "core", "none", "false", "net462")]
+        //[InlineData("netcoreapp1.0", "Debug", "core", "none", "false", "net462")]
+        //[InlineData("netcoreapp1.1", "Debug", "core", "none", "false", "net462")]
+        //[InlineData("netcoreapp1.0", "Release", "core", "Individual", "false", "net462")]
+        //[InlineData("netcoreapp1.1", "Release", "core", "Individual", "false", "net462")]
+        //[InlineData("netcoreapp1.0", "Debug", "core", "Individual", "false", "net462")]
+        //[InlineData("netcoreapp1.1", "Debug", "core", "Individual", "false", "net462")]
+        //[InlineData("netcoreapp1.0", "Release", "core", "Individual", "true", "net462")]
+        //[InlineData("netcoreapp1.1", "Release", "core", "Individual", "true", "net462")]
+        //[InlineData("netcoreapp1.0", "Debug", "core", "Individual", "true", "net462")]
+        //[InlineData("netcoreapp1.1", "Debug", "core", "Individual", "true", "net462")]
         public async Task MvcNET(string templateFramework, string configuration, string msBuildType, string auth, string useLocalDB, string targetFramework)
         {
             string projectName = $"{nameof(MvcNET)}_{Path.GetRandomFileName()}";
@@ -273,67 +273,74 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Tests.EndToEnd
 
         private async Task<string> RestoreBuildPublishAndRun(string testFolder, string projectName, string configuration, string msBuildType, bool isStandAlone = false, string resultUrl = "http://localhost:5000")
         {
-            // dotnet restore
-            string dotnetRestoreArguments = "restore";
-            int? exitCode = ProcessWrapper.RunProcess(DotNetExeName, dotnetRestoreArguments, testFolder, out int? processId2);
-            Assert.True(exitCode.HasValue && exitCode.Value == 0);
-
-            // dotnet build
-            string dotnetBuildArguments = "build";
-            exitCode = ProcessWrapper.RunProcess(DotNetExeName, dotnetBuildArguments, testFolder, out int? processId3);
-            Assert.True(exitCode.HasValue && exitCode.Value == 0);
-
-            // msbuild publish
-            string fileName = "msbuild";
-            string publishOutputFolder = $"bin\\{configuration}\\PublishOutput";
-            string dotnetPublishArguments = $"{projectName}.csproj /p:DeployOnBuild=true /p:Configuration={configuration} /p:PublishUrl={publishOutputFolder}";
-            if (string.Equals(msBuildType, "core"))
-            {
-                dotnetPublishArguments = $"{fileName} {dotnetPublishArguments}";
-                fileName = DotNetExeName;
-            }
-            exitCode = ProcessWrapper.RunProcess(fileName, dotnetPublishArguments, testFolder, out int? processId4);
-            Assert.True(exitCode.HasValue && exitCode.Value == 0);
-
             int? runningProcess = null;
-            string publishOutputFolderFullPath = Path.Combine(testFolder, publishOutputFolder);
-            string dotNetRunArguments = $"{projectName}.dll";
-            fileName = DotNetExeName;
-            if (isStandAlone)
-            {
-                dotNetRunArguments = null;
-                fileName = Path.Combine(publishOutputFolderFullPath, $"{projectName}.exe"); 
-            }
-            exitCode = ProcessWrapper.RunProcess(fileName, dotNetRunArguments, publishOutputFolderFullPath, out runningProcess, waitForExit: false);
-
-            // Wait for 2 seconds for the application to start
-            await Task.Delay(TimeSpan.FromSeconds(2));
-
-            CancellationTokenSource tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
             HttpResponseMessage result = null;
-            while (!tokenSource.IsCancellationRequested)
+            try
             {
-                try
+                // dotnet restore
+                string dotnetRestoreArguments = "restore";
+                int? exitCode = ProcessWrapper.RunProcess(DotNetExeName, dotnetRestoreArguments, testFolder, out int? processId2);
+                Assert.True(exitCode.HasValue && exitCode.Value == 0);
+
+                // dotnet build
+                string dotnetBuildArguments = "build";
+                exitCode = ProcessWrapper.RunProcess(DotNetExeName, dotnetBuildArguments, testFolder, out int? processId3);
+                Assert.True(exitCode.HasValue && exitCode.Value == 0);
+
+                // msbuild publish
+                string fileName = "msbuild";
+                string publishOutputFolder = $"bin\\{configuration}\\PublishOutput";
+                string dotnetPublishArguments = $"{projectName}.csproj /p:DeployOnBuild=true /p:Configuration={configuration} /p:PublishUrl={publishOutputFolder}";
+                if (string.Equals(msBuildType, "core"))
                 {
-                    using (HttpClient client = new HttpClient())
+                    dotnetPublishArguments = $"{fileName} {dotnetPublishArguments}";
+                    fileName = DotNetExeName;
+                }
+                exitCode = ProcessWrapper.RunProcess(fileName, dotnetPublishArguments, testFolder, out int? processId4);
+                Assert.True(exitCode.HasValue && exitCode.Value == 0);
+
+                string publishOutputFolderFullPath = Path.Combine(testFolder, publishOutputFolder);
+                string dotNetRunArguments = $"{projectName}.dll";
+                fileName = DotNetExeName;
+                if (isStandAlone)
+                {
+                    dotNetRunArguments = null;
+                    fileName = Path.Combine(publishOutputFolderFullPath, $"{projectName}.exe");
+                }
+                exitCode = ProcessWrapper.RunProcess(fileName, dotNetRunArguments, publishOutputFolderFullPath, out runningProcess, waitForExit: false);
+
+                // Wait for 2 seconds for the application to start
+                await Task.Delay(TimeSpan.FromSeconds(2));
+
+                CancellationTokenSource tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                while (!tokenSource.IsCancellationRequested)
+                {
+                    try
                     {
-                        result = await client.GetAsync(resultUrl);
-                        if (result.StatusCode == System.Net.HttpStatusCode.OK)
+                        using (HttpClient client = new HttpClient())
                         {
-                            break;
+                            result = await client.GetAsync(resultUrl);
+                            if (result.StatusCode == System.Net.HttpStatusCode.OK)
+                            {
+                                break;
+                            }
+                            await Task.Delay(100);
                         }
-                        await Task.Delay(100);
+                    }
+                    catch
+                    {
                     }
                 }
-                catch
+            }
+            finally
+            {
+                if (runningProcess != null)
                 {
+                    ProcessWrapper.KillProcessTree(runningProcess.Value);
                 }
             }
 
-            if (runningProcess != null)
-            {
-                ProcessWrapper.KillProcessTree(runningProcess.Value);
-            }
+
             try
             {
                 Directory.Delete(testFolder, true);


### PR DESCRIPTION
Ran all the tests locally and all of them ran fine. 

Total tests: 174. Passed: 174. Failed: 0. Skipped: 0.
Test Run Successful.
Test execution time: 47.3093 Minutes

will try running all these tests in a loop to see if I can repro the test cleanup issue.
