### PR TITLE
Remove work-around for mini-publish from websdk

### DIFF
--- a/src/ProjectSystem/Microsoft.NET.Sdk.Web.ProjectSystem.Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.targets
+++ b/src/ProjectSystem/Microsoft.NET.Sdk.Web.ProjectSystem.Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.targets
@@ -43,14 +43,4 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Context>BrowseObject</Context>
     </PropertyPageSchema>
   </ItemGroup>
-  
-  <!-- Enables IIS settings by copiing non framework assemblies to the bin folder -->
-  <Target Name="CopyAssembliesToOutput" AfterTargets="Build" DependsOnTargets="RunResolvePublishAssemblies" Condition="'$(CreateLocalDeployment)' == 'true' And '$(IsInnerBuild)' == 'true'">
-    <Copy SourceFiles="@(ResolvedAssembliesToPublish)" DestinationFiles="$(TargetDir)%(ResolvedAssembliesToPublish.DestinationSubPath)" SkipUnchangedFiles="true" />
-  </Target>
-
-  <!-- Clean target to remove the extra assemblies that were copied to the bin folder -->
-  <Target Name="CleanCopiedAssemblies" AfterTargets="Clean" DependsOnTargets="RunResolvePublishAssemblies" Condition="'$(IsInnerBuild)' == 'true'">
-    <Delete Files="$(TargetDir)%(ResolvedAssembliesToPublish.DestinationSubPath)" ContinueOnError="true" />
-  </Target>
 </Project>


### PR DESCRIPTION
@mlorbetske @BillHiebert 
(VS will set CopyLocalLockFileAssemblies to true instead of CreateLocalDeployment to true.)