### PR TITLE
Turn Off IL Optimization By Default in ASP.NET Core Apps

### DIFF
--- a/src/Web/Microsoft.NET.Sdk.Web.Targets/Sdk.props
+++ b/src/Web/Microsoft.NET.Sdk.Web.Targets/Sdk.props
@@ -11,6 +11,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <!-- Default properties that shouldn't be replaced by the microsoft.net.sdk.props -->
+  <PropertyGroup>
+    <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
+    <DebugType Condition="'$(DebugType)' == ''">pdbonly</DebugType>
+    <PreserveCompilationContext Condition="'$(PreserveCompilationContext)' == ''">true</PreserveCompilationContext>
+  </PropertyGroup>
+
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
   
   <Import Sdk="Microsoft.NET.Sdk.Web.ProjectSystem" Project="Sdk.props" />


### PR DESCRIPTION
Added the 3 properties  we have conditions on to the sdk.props. I left the originals in Microsoft.NET.Sdk.Web.ProjectSystem.props in this props file is ever used outside of our sdk.props.