### PR TITLE
Import default props for TypeScript in ASP.NET Core Projects

### DIFF
--- a/src/ProjectSystem/Microsoft.NET.Sdk.Web.ProjectSystem.Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.props
+++ b/src/ProjectSystem/Microsoft.NET.Sdk.Web.ProjectSystem.Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.props
@@ -44,5 +44,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </ItemGroup>
 
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props"
+		  Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props')"/>
+
 </Project>
 


### PR DESCRIPTION
Summary of the changes:
- Compilation settings for TypeScript files are not properly being set for new ASP.NET Core Projects because the corresponding props are not imported.
    - For example, build does not generate a source map for a TypeScript file even though the checkbox is checked by default in the properties UI.
- This change imports the appropriate props.