### PR TITLE
Treat resolver warnings as errors if using the .All metapackage

### DIFF
--- a/src/ProjectSystem/Microsoft.NET.Sdk.Web.ProjectSystem.Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.targets
+++ b/src/ProjectSystem/Microsoft.NET.Sdk.Web.ProjectSystem.Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.targets
@@ -6,10 +6,11 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"
+         InitialTargets="UpdateWarningsAsErrorsForAllMetapackage">
 
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.targets"
           Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.targets') AND '$(EnableTypeScriptNuGetTarget)' != 'true'"/>
@@ -45,4 +46,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Context>BrowseObject</Context>
     </PropertyPageSchema>
   </ItemGroup>
+
+  <Target Name="UpdateWarningsAsErrorsForAllMetapackage">
+    <PropertyGroup>
+      <WarningsAsErrors Condition="'%(PackageReference.Identity)' == 'Microsoft.AspNetCore.All'">$(WarningsAsErrors);NU1608</WarningsAsErrors>
+    </PropertyGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
WIP, I have been able to verify that this works for restore from the command line, anyone know how to verify this in VS?

CLI Verification:
- [x] downgrade warnings (NU1605) as errors, this should already be the case 
- [x] upgrade warnings (NU1608) as errors if .All metapackage is referenced 
- [x] upgrade warnings (NU1608) remains as is if .All metapackage is not referenced
- [x] upgrade warnings (NU1608) ignored if .All metapackage is not referenced but is disabled via NoWarn or TreatWarningsAsErrors=false

VS Verification:
- [ ] downgrade warnings (NU1605) as errors, this should already be the case 
- [ ] upgrade warnings (NU1608) as errors if .All metapackage is referenced 
- [ ] upgrade warnings (NU1608) remains as is if .All metapackage is not referenced
- [ ] upgrade warnings (NU1608) ignored if .All metapackage is not referenced but is disabled via NoWarn or TreatWarningsAsErrors=false