### PR TITLE
Set the LocalUserSecrets ProjectCapability if UserSecrets is referenced

### DIFF
--- a/src/ProjectSystem/Microsoft.NET.Sdk.Web.ProjectSystem.Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.targets
+++ b/src/ProjectSystem/Microsoft.NET.Sdk.Web.ProjectSystem.Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.targets
@@ -36,6 +36,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ProjectCapability Include="SupportHierarchyContextSvc" />
     <ProjectCapability Include="DynamicDependentFile" />
     <ProjectCapability Include="DynamicFileNesting" />
+
+    <!-- 
+      Enables UI for managing secret values when Microsoft.Extensions.Configuration.UserSecrets 1.x is referenced. 
+      Newer versions of this package include a MSBuild file to set this ProjectCapability, but older versions did not include this.
+      See https://github.com/aspnet/Configuration/blob/9135af4b4e95c080ca4a9f0e91ba5a0b8a561c96/src/Microsoft.Extensions.Configuration.UserSecrets/build/netstandard1.0/Microsoft.Extensions.Configuration.UserSecrets.targets#L10
+    -->
+    <ProjectCapability Include="LocalUserSecrets" Condition=" '$(GenerateUserSecretsAttribute)' == 'true' " />
   </ItemGroup>
 
   <!-- Web specific properties -->


### PR DESCRIPTION
Set the LocalUserSecrets ProjectCapability if UserSecrets is referenced. This is required for netcoreapp1.x projects that reference older versions of Microsoft.Extensions.Configuration.UserSecrets before we added this capability to the package 9cref https://github.com/aspnet/Configuration/pull/750).

cref https://github.com/aspnet/DotNetTools/pull/355 - the VS feature this lights up.

cc @danroth27 @AArnott