### PR TITLE
Adding support for hostingModel in web.config

### DIFF
--- a/src/Publish/Microsoft.NET.Sdk.Publish.Targets/netstandard1.0/TransformTargets/Microsoft.NET.Sdk.Publish.TransformFiles.targets
+++ b/src/Publish/Microsoft.NET.Sdk.Publish.Targets/netstandard1.0/TransformTargets/Microsoft.NET.Sdk.Publish.TransformFiles.targets
@@ -44,7 +44,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     
 
     <TransformWebConfig
-        Condition="'$(_IsAspNetCoreProject)' == 'true' And '$(IsTransformWebConfigDisabled)' != 'true'"
+        Condition="'$(_IsAspNetCoreProject)' == 'true' And '$(IsTransformWebConfigDisabled)' != 'true' And '$(IsWebConfigTransformDisabled)' != 'true'"
         TargetPath="$(TargetPath)"
         PublishDir="$(PublishIntermediateOutputPath)"
         IsPortable="$(_IsPortable)"
@@ -53,7 +53,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         ProjectGuid="$(ProjectGuid)"
         IgnoreProjectGuid="$(IgnoreProjectGuid)" 
         ProjectFullPath="$(MSBuildProjectFullPath)" 
-        SolutionPath ="$(SolutionPath)"/> 
+        SolutionPath ="$(SolutionPath)"
+        AspNetCoreModuleHostingModel="$(AspNetCoreModuleHostingModel)" /> 
   </Target>
 
   <!--

--- a/src/Publish/Microsoft.NET.Sdk.Publish.Tasks/Properties/Resources.Designer.cs
+++ b/src/Publish/Microsoft.NET.Sdk.Publish.Tasks/Properties/Resources.Designer.cs
@@ -11,8 +11,8 @@
 namespace Microsoft.NET.Sdk.Publish.Tasks.Properties {
     using System;
     using System.Reflection;
-
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -1768,6 +1768,15 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Properties {
         public static string VSMSDEPLOY_WebPackageHelpLinkMessage {
             get {
                 return ResourceManager.GetString("VSMSDEPLOY_WebPackageHelpLinkMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The acceptable value for AspNetCoreModuleHostingModel property is either &quot;InProcess&quot; or &quot;OutOfProcess&quot;..
+        /// </summary>
+        public static string WebConfigTransform_HostingModel_Error {
+            get {
+                return ResourceManager.GetString("WebConfigTransform_HostingModel_Error", resourceCulture);
             }
         }
         

--- a/src/Publish/Microsoft.NET.Sdk.Publish.Tasks/Properties/Resources.resx
+++ b/src/Publish/Microsoft.NET.Sdk.Publish.Tasks/Properties/Resources.resx
@@ -1149,4 +1149,7 @@ Environment-Specific Settings:
 ===========================
 For more information on this deploy script visit:	https://go.microsoft.com/fwlink/?LinkID=183544</value>
   </data>
+  <data name="WebConfigTransform_HostingModel_Error" xml:space="preserve">
+    <value>The acceptable value for AspNetCoreModuleHostingModel property is either "InProcess" or "OutOfProcess".</value>
+  </data>
 </root>

--- a/src/Publish/Microsoft.NET.Sdk.Publish.Tasks/Tasks/TransformWebConfig.cs
+++ b/src/Publish/Microsoft.NET.Sdk.Publish.Tasks/Tasks/TransformWebConfig.cs
@@ -56,6 +56,11 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
         /// Native executable extension
         /// </summary>
         public string ExecutableExtension { get; set; }
+        /// <summary>
+        /// AspNetCoreModuleHostingModel defines whether the hosting will be InProcess or OutOfProcess.
+        /// </summary>
+        /// <returns></returns>
+        public string AspNetCoreModuleHostingModel { get; set; }
 
         public override bool Execute()
         {
@@ -84,7 +89,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
             }
 
             string outputFile = Path.GetFileName(TargetPath);
-            XDocument transformedConfig = WebConfigTransform.Transform(webConfigXml, outputFile, IsAzure, IsPortable, ExecutableExtension);
+            XDocument transformedConfig = WebConfigTransform.Transform(webConfigXml, outputFile, IsAzure, IsPortable, ExecutableExtension, AspNetCoreModuleHostingModel);
 
             // Telemetry
             transformedConfig = WebConfigTelemetry.AddTelemetry(transformedConfig, ProjectGuid, IgnoreProjectGuid, SolutionPath, ProjectFullPath);

--- a/test/Publish/Microsoft.NET.Sdk.Publish.Tasks.Tests/Microsoft.NET.Sdk.Publish.Tasks.Tests.csproj
+++ b/test/Publish/Microsoft.NET.Sdk.Publish.Tasks.Tests/Microsoft.NET.Sdk.Publish.Tasks.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="15.1.1012" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.1012" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.VisualStudio" Version="2.2.0" />
   </ItemGroup>

--- a/test/Publish/Microsoft.NET.Sdk.Publish.Tasks.Tests/WebConfigTelemetryTests.cs
+++ b/test/Publish/Microsoft.NET.Sdk.Publish.Tasks.Tests/WebConfigTelemetryTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Tests
         public void WebConfigTelemetry_SetsProjectGuidIfNotOptedOut(string projectGuid)
         {
             // Arrange
-            XDocument transformedWebConfig = WebConfigTransform.Transform(null, "test.exe", configureForAzure: false, isPortable: false, extension:".exe");
+            XDocument transformedWebConfig = WebConfigTransform.Transform(null, "test.exe", configureForAzure: false, isPortable: false, extension:".exe", aspNetCoreHostingModel:null);
             Assert.True(XNode.DeepEquals(WebConfigTemplate, transformedWebConfig));
             
             //Act 
@@ -81,7 +81,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Tests
         public void WebConfigTelemetry_DoesNotSetProjectGuidIfOptedOut_ThroughIgnoreProjectGuid(string projectGuid)
         {
             // Arrange
-            XDocument transformedWebConfig = WebConfigTransform.Transform(null, "test.exe", configureForAzure: false, isPortable: false, extension: ".exe");
+            XDocument transformedWebConfig = WebConfigTransform.Transform(null, "test.exe", configureForAzure: false, isPortable: false, extension: ".exe", aspNetCoreHostingModel:null);
             Assert.True(XNode.DeepEquals(WebConfigTemplate, transformedWebConfig));
 
             //Act 
@@ -96,7 +96,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Tests
         public void WebConfigTelemetry_RemovesProjectGuidIfOptedOut_ThroughIgnoreProjectGuid(string projectGuid)
         {
             // Arrange
-            XDocument transformedWebConfig = WebConfigTransform.Transform(null, "test.exe", configureForAzure: false, isPortable: false, extension: ".exe");
+            XDocument transformedWebConfig = WebConfigTransform.Transform(null, "test.exe", configureForAzure: false, isPortable: false, extension: ".exe", aspNetCoreHostingModel:null);
             Assert.True(XNode.DeepEquals(WebConfigTemplate, transformedWebConfig));
             // Adds Guid to the config
             XDocument transformedWebConfigWithGuid = WebConfigTelemetry.AddTelemetry(transformedWebConfig, projectGuid, false, null, null);
@@ -116,7 +116,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Tests
         {
             // Arrange
             string projectFullPath = GetTestProjectsFullPath();
-            XDocument transformedWebConfig = WebConfigTransform.Transform(null, "test.exe", configureForAzure: false, isPortable: false, extension: ".exe");
+            XDocument transformedWebConfig = WebConfigTransform.Transform(null, "test.exe", configureForAzure: false, isPortable: false, extension: ".exe", aspNetCoreHostingModel: null);
             string previousValue = Environment.GetEnvironmentVariable(TelemetryOptout);
 
             //Act 
@@ -135,7 +135,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Tests
         {
             // Arrange
             string projectFullPath = GetTestProjectsFullPath();
-            XDocument transformedWebConfig = WebConfigTransform.Transform(null, "test.exe", configureForAzure: false, isPortable: false, extension: ".exe");
+            XDocument transformedWebConfig = WebConfigTransform.Transform(null, "test.exe", configureForAzure: false, isPortable: false, extension: ".exe", aspNetCoreHostingModel: null);
             string previousValue = Environment.GetEnvironmentVariable(TelemetryOptout);
 
             //Act 


### PR DESCRIPTION
https://github.com/aspnet/websdk/issues/283

@shirhatti @natemcmaster @jkotalik @mlorbetske 

```
If web.config is present in the project:
	If hostingModel attribute is already set in the web.config, then web.config transform will respect the current hostingModel value in web.config.
	
	If hostingModel attribute is not set, then hostingModel attribute is set to the value of AspNetCoreModuleHostingModel msbuild property.
		Web.Config transform will set the hostingModel attribute value to InProcess if AspNetCoreModuleHostingModel property is set to InProcess.
		Web.Config transform will set the hostingModel attribute value to OutOfProcess if AspNetCoreModuleHostingModel property is set to OutOfProcess.
		Web.Config transform will not set the hostingModel attribute value if AspNetCoreModuleHostingModel is not set or set to empty.
		Web.Config transform will throw an exception if AspNetCoreModuleHostingModel property is set to anything other than InProcess, OutOfProcess or Empty.


If web.config is not present in the project:
	HostingModel attribute is set to the value of AspNetCoreModuleHostingModel msbuild property.
		Web.Config transform will set the hostingModel attribute value to InProcess if AspNetCoreModuleHostingModel property is set to InProcess.
		Web.Config transform will set the hostingModel attribute value to OutOfProcess if AspNetCoreModuleHostingModel property is set to OutOfProcess.
		Web.Config transform will not set the hostingModel attribute value if AspNetCoreModuleHostingModel is not set or set to empty.
		Web.Config transform will throw an exception if AspNetCoreModuleHostingModel property is set to anything other than InProcess, OutOfProcess or Empty.
```