### PR TITLE
Updating the check to detemine if an app is portable

### DIFF
--- a/src/Publish/Microsoft.NET.Sdk.Publish.Targets/netstandard1.0/TransformTargets/Microsoft.NET.Sdk.Publish.TransformFiles.targets
+++ b/src/Publish/Microsoft.NET.Sdk.Publish.Targets/netstandard1.0/TransformTargets/Microsoft.NET.Sdk.Publish.TransformFiles.targets
@@ -36,7 +36,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <PropertyGroup>
       <_IsAspNetCoreProject Condition="%(ProjectCapability.Identity) == 'AspNetCore'">true</_IsAspNetCoreProject>
-      <_IsPortable Condition=" '$(_IsPortable)' == '' And '$(RuntimeIdentifier)' != '' ">false</_IsPortable>
+      <_IsPortable Condition=" '$(_IsPortable)' == '' And '$(SelfContained)' == 'true' ">false</_IsPortable>
       <_IsPortable Condition=" '$(_IsPortable)' == ''">true</_IsPortable>
       <_ExecutableExtension Condition="'$(_ExecutableExtension)' == '' and $(RuntimeIdentifier.StartsWith('win'))">.exe</_ExecutableExtension>
       <_TransformWebConfigForAzure Condition=" '$(WEBSITE_SITE_NAME)' != '' Or '$(DOTNET_CONFIGURE_AZURE)' == 'true' Or '$(DOTNET_CONFIGURE_AZURE)' == '1'">true</_TransformWebConfigForAzure>


### PR DESCRIPTION
@mlorbetske 

SelfContained is already getting set in core sdk based on RID.

https://github.com/dotnet/sdk/blob/ce6fd6adcc747ccb28a918c312b416ff10056bce/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.RuntimeIdentifierInference.targets#L108-L109