### PR TITLE
Always generate a deps file when referencing WebSdk

### DIFF
--- a/src/ProjectSystem/Microsoft.NET.Sdk.Web.ProjectSystem.Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.props
+++ b/src/ProjectSystem/Microsoft.NET.Sdk.Web.ProjectSystem.Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.props
@@ -20,6 +20,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <OutputType>Exe</OutputType>
     <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
     <DebugType Condition="'$(DebugType)' == ''">pdbonly</DebugType>
+    <GenerateDependencyFile Condition="'$(GenerateDependencyFile)' == ''">true</GenerateDependencyFile>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <IsPackable Condition="'$(IsPackable)' == ''">false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
See https://github.com/aspnet/Razor/issues/2077 for further background on this.

`PreserveCompilationContext` was moved to Razor.Sdk, and we intend on conditionally setting it (only if a project has any views to compile). However, NET.Sdk uses PreserveCompilationContext to determine if the deps file needs to be generated on desktop. See https://github.com/dotnet/sdk/blob/753207c916132c131052aa45196653bd7993b23a/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets#L71-L74. Mvc relies on this file to compose the application.

This change makes it so that referencing the Web.Sdk always produces a deps file.