### PR TITLE
Adds a check to see whether the original extension was exe, if it is, just use the path to the exe

### DIFF
--- a/src/Publish/Microsoft.NET.Sdk.Publish.Tasks/WebConfigTransform.cs
+++ b/src/Publish/Microsoft.NET.Sdk.Publish.Tasks/WebConfigTransform.cs
@@ -60,6 +60,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
             // Forward slashes currently work neither in AspNetCoreModule nor in dotnet so they need to be
             // replaced with backwards slashes when the application is published on a non-Windows machine
             var appPath = Path.Combine(".", appName).Replace("/", "\\");
+            var originalExtension = Path.GetExtension(appPath);
             RemoveLauncherArgs(aspNetCoreElement);
 
             if (!isPortable)
@@ -67,7 +68,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
                 appPath = Path.ChangeExtension(appPath, !string.IsNullOrWhiteSpace(extension) ? extension : null);
             }
 
-            if (!isPortable)
+            if (!isPortable || string.Equals(originalExtension, ".exe", StringComparison.OrdinalIgnoreCase))
             {
                 aspNetCoreElement.SetAttributeValue("processPath", appPath);
             }

--- a/test/Publish/Microsoft.NET.Sdk.Publish.Tasks.Tests/WebConfigTransformTests.cs
+++ b/test/Publish/Microsoft.NET.Sdk.Publish.Tasks.Tests/WebConfigTransformTests.cs
@@ -293,6 +293,19 @@ namespace Microsoft.Net.Sdk.Publish.Tasks.Tests
                 aspNetCoreElement));
         }
 
+        [Fact]
+        public void WebConfigTransform_configures_full_framework_apps_correctly()
+        {
+            var aspNetCoreElement =
+                WebConfigTransform.Transform(WebConfigTemplate, "test.exe", configureForAzure: false, isPortable: true, extension: ".exe", aspNetCoreHostingModel: null)
+                    .Descendants("aspNetCore").Single();
+
+            Assert.True(XNode.DeepEquals(
+                XDocument.Parse(@"<aspNetCore processPath="".\test.exe"" stdoutLogEnabled=""false""
+                     stdoutLogFile="".\logs\stdout"" />").Root,
+                aspNetCoreElement));
+        }
+
         [Theory]
         [InlineData("%LAUNCHER_ARGS%", "")]
         [InlineData(" %launcher_ARGS%", "")]


### PR DESCRIPTION
Fixes an issue where if a net4xx app is determined to be portable, the ancm element still uses dotnet as the process to launch

Merging to release/2.1 as requested