### PR TITLE
Add logic to resolve implicit versions of Microsoft.AspNetCore.App

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,8 +13,8 @@ REPOROOT="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 source "$REPOROOT/scripts/common/_prettyprint.sh"
 export DOTNET_VERSION=2.1.300-preview2-008248
 export WebSdkRoot=$REPOROOT
-export WebSdkReferences=$WebSdkRoot/references/ 
-export WebSdkSource=$WebSdkRoot/src/ 
+export WebSdkReferences=$WebSdkRoot/references/
+export WebSdkSource=$WebSdkRoot/src/
 export WebSdkBuild=$WebSdkRoot/build/
 
 [ -z "$BuildConfiguration" ] && export BuildConfiguration=Release

--- a/build/package.proj
+++ b/build/package.proj
@@ -9,8 +9,8 @@
     <BuildBranchName Condition="'$(BuildBranchName)' == ''">dev</BuildBranchName>
     <WebSdkVersion Condition="'$(WebSdkVersion)' == ''">$(VersionPrefix)-$(BuildBranchName)$(CurrentDate)-$(BUILD_BUILDNUMBER)</WebSdkVersion>
   </PropertyGroup>
-  
-  <Target Name="Package" 
+
+  <Target Name="Package"
           Condition="'$(SkipPackages)' != 'true'"
           DependsOnTargets="_Package"/>
 
@@ -44,6 +44,7 @@
 
     <MSBuild Projects="@(WebSdkPackageProject)"
          Targets ="Restore;Build;Pack"/>
-    
+
   </Target>
+
 </Project>

--- a/build/test.proj
+++ b/build/test.proj
@@ -6,7 +6,7 @@
     <DotNetSdksFolder>$(DOTNET_INSTALL_DIR)/Sdk/$(DOTNET_VERSION)/Sdks</DotNetSdksFolder>
   </PropertyGroup>
 
-  <Target Name="Test" 
+  <Target Name="Test"
           Condition="'$(SkipTests)' != 'true'"
           DependsOnTargets="_Test"/>
 
@@ -39,13 +39,13 @@
         DestinationFiles="$(DotNetSdksFolder)/Microsoft.NET.Sdk.Web.ProjectSystem/Sdk/Sdk.targets"
         OverwriteReadOnlyFiles="true" />
 
-    <!--Copy web sdks-->
-    <Copy SourceFiles="$(WebSdkSource)/Web/Microsoft.NET.Sdk.Web.Targets/Sdk.props"
-        DestinationFiles="$(DotNetSdksFolder)/Microsoft.NET.Sdk.Web/Sdk/Sdk.props"
-        OverwriteReadOnlyFiles="true" />
+    <ItemGroup>
+      <SDKFiles Include="$(WebSdkSource)/Web/Microsoft.NET.Sdk.Web.Targets/*.props;$(WebSdkSource)/Web/Microsoft.NET.Sdk.Web.Targets/*.targets" />
+    </ItemGroup>
 
-    <Copy SourceFiles="$(WebSdkSource)/Web/Microsoft.NET.Sdk.Web.Targets/Sdk.targets"
-        DestinationFiles="$(DotNetSdksFolder)/Microsoft.NET.Sdk.Web/Sdk/Sdk.targets"
+    <!--Copy web sdks-->
+    <Copy SourceFiles="@(SDKFiles)"
+        DestinationFolder="$(DotNetSdksFolder)/Microsoft.NET.Sdk.Web/Sdk/"
         OverwriteReadOnlyFiles="true" />
 
     <!-- Copy Publish targets and projectsystem targets-->

--- a/pack/Microsoft.NET.Sdk.Web/Microsoft.NET.Sdk.Web.csproj
+++ b/pack/Microsoft.NET.Sdk.Web/Microsoft.NET.Sdk.Web.csproj
@@ -18,11 +18,11 @@
     <PackageReference Include="Microsoft.NET.Sdk.Web.ProjectSystem" Version="$(PackageVersion)" />
     <PackageReference Include="Microsoft.NET.Sdk.Publish" Version="$(PackageVersion)" />
 
-    <Content Include="$(WebSdkSource)\Web\Microsoft.NET.Sdk.Web.Targets\Sdk.props">
+    <Content Include="$(WebSdkSource)\Web\Microsoft.NET.Sdk.Web.Targets\*.props">
       <Pack>true</Pack>
       <PackagePath>Sdk</PackagePath>
     </Content>
-    <Content Include="$(WebSdkSource)\Web\Microsoft.NET.Sdk.Web.Targets\Sdk.targets">
+    <Content Include="$(WebSdkSource)\Web\Microsoft.NET.Sdk.Web.Targets\*.targets">
       <Pack>true</Pack>
       <PackagePath>Sdk</PackagePath>
     </Content>

--- a/src/ProjectSystem/Microsoft.NET.Sdk.Web.ProjectSystem.Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.targets
+++ b/src/ProjectSystem/Microsoft.NET.Sdk.Web.ProjectSystem.Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -48,8 +48,8 @@ Copyright (c) .NET Foundation. All rights reserved.
           <ProjectCapability Include="DynamicDependentFile" />
           <ProjectCapability Include="DynamicFileNesting" />
 
-          <!-- 
-            Enables UI for managing secret values when Microsoft.Extensions.Configuration.UserSecrets 1.x is referenced. 
+          <!--
+            Enables UI for managing secret values when Microsoft.Extensions.Configuration.UserSecrets 1.x is referenced.
             Newer versions of this package include a MSBuild file to set this ProjectCapability, but older versions did not include this.
             See https://github.com/aspnet/Configuration/blob/9135af4b4e95c080ca4a9f0e91ba5a0b8a561c96/src/Microsoft.Extensions.Configuration.UserSecrets/build/netstandard1.0/Microsoft.Extensions.Configuration.UserSecrets.targets#L10
           -->

--- a/src/Web/Microsoft.NET.Sdk.Web.Targets/Sdk.DefaultItems.targets
+++ b/src/Web/Microsoft.NET.Sdk.Web.Targets/Sdk.DefaultItems.targets
@@ -1,0 +1,143 @@
+<!--
+***********************************************************************************************
+Sdk.DefaultItems.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<!--
+    Determine the version (including patch) of ASPNET Core to target.
+
+    When targeting ASPNET Core, the TargetFramework is used to specify the major and minor version of the runtime to use.
+    By default, the patch version is inferred. The general logic is that self-contained apps will target the latest patch
+    that the SDK knows about, while framework-dependent apps will target the ".0" patch (and roll forward to the latest
+    patch installed at runtime).
+
+    The TargetLatestAspNetCoreRuntimePatch property can be set to true or false to explicitly opt in or out of the logic
+    to roll forward to the latest patch, regardless of whether the app is self-contained or framework-dependent. The
+    default value of this property is TargetLatestRuntimePatch set by the dotnet SDK.
+
+    The AspNetCoreAppRuntimeFrameworkVersion and AspNetCoreAllRuntimeFrameworkVersion are where the actual versions of the
+    ASPNET Core runtimes to target is stored. They are the versions that are used in the implicit PackageReference to
+    Microsoft.AspNetCore.App and Microsoft.AspNetCore.All. The AspNetCoreAppRuntimeFrameworkVersion and
+    AspNetCoreAllRuntimeFrameworkVersion can also be set explicitly, which will disable all the other logic that
+    automatically selects the version of .NET Core to target.
+
+    The framework version that is written to the runtimeconfig.json file is based on the actual resolved package version
+    of Microsoft.AspNetCore.App or Microsoft.AspNetCore.All. This is to allow floating the verion number (i.e. the user
+    could set the version to "2.0-*".
+
+  -->
+  <Choose>
+    <When Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" >
+
+      <!-- Default patch version of .All Framework -->
+      <PropertyGroup Condition="'$(DefaultAspNetCoreAllPatchVersion)' == ''">
+        <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
+            provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+        <DefaultAspNetCoreAllPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '$(BundledAspNetCoreAllTargetFrameworkVersion)'">$(BundledAspNetCoreAllPackageVersion)</DefaultAspNetCoreAllPatchVersion>
+        <!-- If not covered by the previous cases use the target framework version for the default patch version -->
+        <DefaultAspNetCoreAllPatchVersion Condition="'$(DefaultAspNetCoreAllPatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</DefaultAspNetCoreAllPatchVersion>
+      </PropertyGroup>
+
+      <!-- Default patch version of .App Framework -->
+      <PropertyGroup Condition="'$(DefaultAspNetCoreAppPatchVersion)' == ''">
+        <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
+            provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+        <DefaultAspNetCoreAppPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '$(BundledAspNetCoreAppTargetFrameworkVersion)'">$(BundledAspNetCoreAppPackageVersion)</DefaultAspNetCoreAppPatchVersion>
+        <!-- If not covered by the previous cases use the target framework version for the default patch version -->
+        <DefaultAspNetCoreAppPatchVersion Condition="'$(DefaultAspNetCoreAppPatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</DefaultAspNetCoreAppPatchVersion>
+      </PropertyGroup>
+
+      <!-- Latest patch version of .All Framework -->
+      <PropertyGroup Condition="'$(LatestAspNetCoreAllPatchVersion)' == ''">
+        <!-- Placeholder for setting latest patch version using the bundled version from CLI -->
+        <!-- <LatestAspNetCoreAllPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.1'">$(LatestPatchVersionForAspNetCoreAll2_1)</LatestAspNetCoreAllPatchVersion> -->
+
+        <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
+            provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+        <LatestAspNetCoreAllPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '$(BundledAspNetCoreAllTargetFrameworkVersion)'">$(BundledAspNetCoreAllPackageVersion)</LatestAspNetCoreAllPatchVersion>
+        <!-- If not covered by the previous cases use the target framework version for the latest patch version -->
+        <LatestAspNetCoreAllPatchVersion Condition="'$(LatestAspNetCoreAllPatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</LatestAspNetCoreAllPatchVersion>
+      </PropertyGroup>
+
+      <!-- Latest patch version of .App Framework -->
+      <PropertyGroup Condition="'$(LatestAspNetCoreAppPatchVersion)' == ''">
+        <!-- Placeholder for setting latest patch version using the bundled version from CLI -->
+        <!-- <LatestAspNetCoreAppPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.1'">$(LatestPatchVersionForAspNetCoreApp2_1)</LatestAspNetCoreAppPatchVersion> -->
+
+        <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
+            provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+        <LatestAspNetCoreAppPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '$(BundledAspNetCoreAppTargetFrameworkVersion)'">$(BundledAspNetCoreAppPackageVersion)</LatestAspNetCoreAppPatchVersion>
+        <!-- If not covered by the previous cases use the target framework version for the latest patch version -->
+        <LatestAspNetCoreAppPatchVersion Condition="'$(LatestAspNetCoreAppPatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</LatestAspNetCoreAppPatchVersion>
+      </PropertyGroup>
+
+      <!-- Determine the default values of TargetLatestAspNetCoreRuntimePatch -->
+      <PropertyGroup Condition="'$(TargetLatestAspNetCoreRuntimePatch)' == ''">
+        <TargetLatestAspNetCoreRuntimePatch>false</TargetLatestAspNetCoreRuntimePatch>
+        <TargetLatestAspNetCoreRuntimePatch Condition="'$(SelfContained)' == 'true'">true</TargetLatestAspNetCoreRuntimePatch>
+        <TargetLatestAspNetCoreRuntimePatch Condition="'$(TargetLatestRuntimePatch)' != ''">$(TargetLatestRuntimePatch)</TargetLatestAspNetCoreRuntimePatch>
+      </PropertyGroup>
+
+      <!-- Set the framework version of .All Framework -->
+      <PropertyGroup Condition="'$(AspNetCoreAllRuntimeFrameworkVersion)' == ''">
+        <AspNetCoreAllRuntimeFrameworkVersion>$(DefaultAspNetCoreAllPatchVersion)</AspNetCoreAllRuntimeFrameworkVersion>
+        <AspNetCoreAllRuntimeFrameworkVersion Condition="'$(TargetLatestAspNetCoreRuntimePatch)' == 'true'">$(LatestAspNetCoreAllPatchVersion)</AspNetCoreAllRuntimeFrameworkVersion>
+      </PropertyGroup>
+
+      <!-- Set the framework version of .App Framework -->
+      <PropertyGroup Condition="'$(AspNetCoreAppRuntimeFrameworkVersion)' == ''">
+        <AspNetCoreAppRuntimeFrameworkVersion >$(DefaultAspNetCoreAppPatchVersion)</AspNetCoreAppRuntimeFrameworkVersion>
+        <AspNetCoreAppRuntimeFrameworkVersion Condition="'$(TargetLatestAspNetCoreRuntimePatch)' == 'true'">$(LatestAspNetCoreAppPatchVersion)</AspNetCoreAppRuntimeFrameworkVersion>
+      </PropertyGroup>
+
+      <PropertyGroup>
+        <_AspNetCoreAllPackageName>Microsoft.AspNetCore.All</_AspNetCoreAllPackageName>
+        <_AspNetCoreAppPackageName>Microsoft.AspNetCore.App</_AspNetCoreAppPackageName>
+      </PropertyGroup>
+
+      <ItemGroup>
+        <!-- Determine if ASPNET metapackage references without version numbers exist -->
+        <_AspNetCoreAllReference Include="@(PackageReference->WithMetadataValue('Identity', '$(_AspNetCoreAllPackageName)'))" />
+        <_ExplicitAspNetCoreAllReference Include="@(_AspNetCoreAllReference->HasMetadata('Version'))" />
+        <_AspNetCoreAppReference Include="@(PackageReference->WithMetadataValue('Identity', '$(_AspNetCoreAppPackageName)'))" />
+        <_ExplicitAspNetCoreAppReference Include="@(_AspNetCoreAppReference->HasMetadata('Version'))" />
+
+        <!-- Update implicit ASPNET metapackage references if needed -->
+        <PackageReference
+          Update="$(_AspNetCoreAllPackageName)"
+          Condition="'@(_AspNetCoreAllReference->Count())' == '1' AND '@(_ExplicitAspNetCoreAllReference->Count())' == '0'">
+          <Version>$(AspNetCoreAllRuntimeFrameworkVersion)</Version>
+          <IsImplicitlyDefined>true</IsImplicitlyDefined>
+          <PrivateAssets>All</PrivateAssets>
+          <Publish>true</Publish>
+        </PackageReference>
+        <PackageReference
+          Update="$(_AspNetCoreAppPackageName)"
+          Condition="'@(_AspNetCoreAppReference->Count())' == '1' AND '@(_ExplicitAspNetCoreAppReference->Count())' == '0'">
+          <Version>$(AspNetCoreAppRuntimeFrameworkVersion)</Version>
+          <IsImplicitlyDefined>true</IsImplicitlyDefined>
+          <PrivateAssets>All</PrivateAssets>
+          <Publish>true</Publish>
+        </PackageReference>
+
+        <!-- Update list of implicit platform packages which require version verification -->
+        <ExpectedPlatformPackages
+          Include="$(_AspNetCoreAllPackageName)"
+          ExpectedVersion="$(AspNetCoreAllRuntimeFrameworkVersion)"
+          Condition="'@(_AspNetCoreAllReference->Count())' == '1' AND '@(_ExplicitAspNetCoreAllReference->Count())' == '0'"/>
+        <ExpectedPlatformPackages
+          Include="$(_AspNetCoreAppPackageName)"
+          ExpectedVersion="$(AspNetCoreAppRuntimeFrameworkVersion)"
+          Condition="'@(_AspNetCoreAppReference->Count())' == '1' AND '@(_ExplicitAspNetCoreAppReference->Count())' == '0'"/>
+      </ItemGroup>
+
+    </When>
+  </Choose>
+</Project>

--- a/src/Web/Microsoft.NET.Sdk.Web.Targets/Sdk.targets
+++ b/src/Web/Microsoft.NET.Sdk.Web.Targets/Sdk.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -14,9 +14,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
   <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.targets" />
-  
+
   <Import Sdk="Microsoft.NET.Sdk.Web.ProjectSystem" Project="Sdk.targets" />
-  
+
   <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.targets" />
+
+  <Import Project="$(MSBuildThisFileDirectory)Sdk.DefaultItems.targets" />
 
 </Project>


### PR DESCRIPTION
Addresses https://github.com/aspnet/Universe/issues/967.

We are adding logic to resolve implicit version numbers for the Microsoft.AspNetCore.App metapackage in aspnet apps which uses the Web SDK. This is for rc1 and I will send a shiproom email for ask mode. Please continue reviewing the PR but I will not merged until approved.

I'm open to implementation and naming suggestions but I've been trying to keep in line with what I have seen in the dotnet SDK, https://github.com/dotnet/sdk/pull/2085/files.