### PR TITLE
Use source-build's sdk dir when defined as the dotnet dir to be able to source-build on Windows

### DIFF
--- a/build/WebSdkEnv.cmd
+++ b/build/WebSdkEnv.cmd
@@ -4,6 +4,10 @@ if not defined BuildConfiguration (
     set "BuildConfiguration=Release"
 )
 
+if defined DotNetCoreSdkDir (
+	set "DOTNET_INSTALL_DIR=%DotNetCoreSdkDir%"
+)
+
 if not defined DOTNET_INSTALL_DIR (
     set "DOTNET_INSTALL_DIR=%LocalAppData%\Microsoft\dotnet"
 )


### PR DESCRIPTION
We're trying to enable source-build on windows because for our devs working on the full product on windows we want them to be able to build the full stack on windows.

cc: @weshaggard @vijayrkn