### PR TITLE
Prevent copying removed generated content

### DIFF
--- a/src/Publish/Microsoft.NET.Sdk.Publish.Targets/netstandard1.0/ComputeTargets/Microsoft.NET.Sdk.Publish.ComputeFiles.targets
+++ b/src/Publish/Microsoft.NET.Sdk.Publish.Targets/netstandard1.0/ComputeTargets/Microsoft.NET.Sdk.Publish.ComputeFiles.targets
@@ -51,6 +51,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   
   <Target Name="_IncludePrePublishGeneratedContent" BeforeTargets="GetCopyToPublishDirectoryItems" Condition=" '$(EnableDefaultItems)' == 'true' And '$(EnableDefaultContentItems)' == 'true' ">
     <ItemGroup>
+      <!-- First, clean up previously generated content that may have been removed. -->
+      <ContentWithTargetPath Remove="@(ContentWithTargetPath)" Condition="!Exists('%(Identity)')" />
+      <!-- Next, include any newly generated content. -->
       <_WebProjectGeneratedContent Include="wwwroot\**" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(_ContentIncludedByDefault)" />
       <ContentWithTargetPath Include="@(_WebProjectGeneratedContent)" TargetPath="%(Identity)" CopyToPublishDirectory="PreserveNewest" />
     </ItemGroup>


### PR DESCRIPTION
When using the `PrepareForPublish` hook, extra content (CSS, JS, etc.) is often generated to be published with the project. However, sometimes the steps taken during this hook will also cause content that was previously generated to be removed. For instance, a JS library may have been used but is not used anymore, so a `gulp` task may remove it from `wwwroot/lib`. When this happens, the SDK should respond appropriately or else it will try to copy non-existing files to the publish output directory, resulting in build-halting errors. This commit updates the `_IncludePrePublishGeneratedContent` target to do just that.