### PR TITLE
Mark SDK packages as NonShipping="true"

### DIFF
--- a/build/publish.proj
+++ b/build/publish.proj
@@ -22,7 +22,7 @@
   <Import Project="$(WebSdkRoot)/Publish/obj/Publish.csproj.nuget.g.targets" Condition="Exists('$(WebSdkRoot)/Publish/obj/Publish.csproj.nuget.g.targets')" />
   -->
     <ItemGroup>
-      <SignedPackages Include="$(SignedPackagesPath)/**/*.nupkg" />
+      <SignedPackages Include="$(SignedPackagesPath)/**/*.nupkg" ManifestArtifactData="NonShipping=true" />
     </ItemGroup>
 
   <Target Name="Publish"


### PR DESCRIPTION
SDK packages are only mean to transport bits to other builds, but are not meant to ship to NuGet.org