### PR TITLE
Add warning when implicit package reference is used

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -7,7 +7,7 @@
   <PropertyGroup Condition=" '$(PackageVersion)' == '' ">
 
     <!-- If $(PB_VersionStamp) is empty and $(PB_IsStable) is not true, then a default PackageBuildQuality will be added. -->
-    <PackageReleaseVersion Condition="'$(PackageReleaseVersion)' == '' ">2.1.400</PackageReleaseVersion>
+    <PackageReleaseVersion Condition="'$(PackageReleaseVersion)' == '' ">2.1.402</PackageReleaseVersion>
     <PackageBuildQuality>$(PB_VersionStamp)</PackageBuildQuality>
     <PackageBuildQuality Condition=" '$(PackageBuildQuality)' == '' And '$(PB_IsStable)' != 'true' ">preview1</PackageBuildQuality>
     <PackageDateTime Condition="'$(PackageDateTime)' == ''">$([System.DateTime]::Now.ToString("yyyyMMdd"))</PackageDateTime>

--- a/src/Web/Microsoft.NET.Sdk.Web.Targets/Sdk.DefaultItems.targets
+++ b/src/Web/Microsoft.NET.Sdk.Web.Targets/Sdk.DefaultItems.targets
@@ -124,7 +124,6 @@ Copyright (c) .NET Foundation. All rights reserved.
           Update="$(_AspNetCoreAllPackageName)"
           Condition="'@(_AspNetCoreAllReference->Count())' == '1' AND '@(_ExplicitAspNetCoreAllReference->Count())' == '0'">
           <Version>$(AspNetCoreAllRuntimeFrameworkVersion)</Version>
-          <IsImplicitlyDefined>true</IsImplicitlyDefined>
           <PrivateAssets>All</PrivateAssets>
           <Publish>true</Publish>
         </PackageReference>
@@ -132,7 +131,6 @@ Copyright (c) .NET Foundation. All rights reserved.
           Update="$(_AspNetCoreAppPackageName)"
           Condition="'@(_AspNetCoreAppReference->Count())' == '1' AND '@(_ExplicitAspNetCoreAppReference->Count())' == '0'">
           <Version>$(AspNetCoreAppRuntimeFrameworkVersion)</Version>
-          <IsImplicitlyDefined>true</IsImplicitlyDefined>
           <PrivateAssets>All</PrivateAssets>
           <Publish>true</Publish>
         </PackageReference>
@@ -150,4 +148,18 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     </When>
   </Choose>
+
+  <Target Name="_WarnIfImplicitAspnetCoreAppPackageReferencesAreUsed"
+    Condition=" '$(SuppressImplicitAspNetCorePackageReferenceWarning)' != 'true' "
+    BeforeTargets="CollectPackageReferences">
+    <Warning
+      Text="The PackageReference to $(_AspNetCoreAllPackageName) is missing the Version attribute. Restore will default to using version $(AspNetCoreAllRuntimeFrameworkVersion). See https://aka.ms/aspnetcore/2.1/metapackage-refs for more details about this warning."
+      Condition="'@(_AspNetCoreAllReference->Count())' == '1' AND '@(_ExplicitAspNetCoreAllReference->Count())' == '0'"
+      File="$(MSBuildProjectFullPath)" />
+    <Warning
+      Text="The PackageReference to $(_AspNetCoreAppPackageName) is missing the Version attribute. Restore will default to using version $(AspNetCoreAppRuntimeFrameworkVersion). See https://aka.ms/aspnetcore/2.1/metapackage-refs for more details about this warning."
+      Condition="'@(_AspNetCoreAppReference->Count())' == '1' AND '@(_ExplicitAspNetCoreAppReference->Count())' == '0'"
+      File="$(MSBuildProjectFullPath)" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
See discussion on https://github.com/aspnet/Home/issues/3292

Changes:

* Remove IsImplicitlyDefined=true. This will cause Visual Studio to display updates to Micrsoft.AspNetCore.App in the NuGet UI. When users upgrade, VS will add the version to the PackageReference in the project (I tested manually)
* Add a warning when the implicit reference is used to nudge users back to using an explicit version. (cc @DamianEdwards for wording review)

"The PackageReference to Microsoft.AspNetCore.App is missing the Version attribute. Setting the default version to 2.1.1. See https://aka.ms/aspnetcore/2.1/metapackage-refs for more details about this warning."