### PR TITLE
Adding support for XDT in Websdk

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -5,6 +5,6 @@
     <add key="DotNetCore" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="BuildTools" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
     <add key="NuGetBuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
-	<add key="DotNetWebMyGet" value="https://dotnet.myget.org/F/dotnet-web/api/v3/index.json" />
+    <add key="DotNetWebMyGet" value="https://dotnet.myget.org/F/dotnet-web/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -5,5 +5,6 @@
     <add key="DotNetCore" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="BuildTools" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
     <add key="NuGetBuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
+	<add key="DotNetWebMyGet" value="https://dotnet.myget.org/F/dotnet-web/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ done
 REPOROOT="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 source "$REPOROOT/scripts/common/_prettyprint.sh"
-export DOTNET_VERSION=2.1.300
+export DOTNET_VERSION=2.1.302
 if [ -n "$DotNetCoreSdkDir" ]
 then
     export DOTNET_VERSION=$( ${DotNetCoreSdkDir}/dotnet --version )

--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ then
     [ -d "$DOTNET_INSTALL_DIR" ] || mkdir -p $DOTNET_INSTALL_DIR
 
     DOTNET_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.sh"
-    curl -sSL "$DOTNET_INSTALL_SCRIPT_URL" | bash /dev/stdin --verbose --version 2.1.300
+    curl -sSL "$DOTNET_INSTALL_SCRIPT_URL" | bash /dev/stdin --verbose --version 2.1.302
 
     curl --retry 10 -s -SL -f --create-dirs -o $DOTNET_INSTALL_DIR/buildtools.tar.gz https://aspnetcore.blob.core.windows.net/buildtools/netfx/4.6.1/netfx.4.6.1.tar.gz
     [ -d "$DOTNET_INSTALL_DIR/buildtools/net461" ] || mkdir -p $DOTNET_INSTALL_DIR/buildtools/net461

--- a/build/WebSdkEnv.cmd
+++ b/build/WebSdkEnv.cmd
@@ -13,7 +13,7 @@ if not defined DOTNET_INSTALL_DIR (
 )
 
 if not defined DOTNET_VERSION (
-    set DOTNET_VERSION=2.1.300
+    set DOTNET_VERSION=2.1.302
 )
 
 if not defined FeedTasksPackage (

--- a/build/test.proj
+++ b/build/test.proj
@@ -72,8 +72,17 @@
         DestinationFiles="$(DotNetSdksFolder)/Microsoft.NET.Sdk.Publish/tools/net46/Microsoft.NET.Sdk.Publish.Tasks.dll"
         OverwriteReadOnlyFiles="true" />
 
-    <Copy SourceFiles="$(WebSdkRoot)/bin/$(Configuration)/netstandard1.3/Microsoft.NET.Sdk.Publish.Tasks.dll"
-        DestinationFiles="$(DotNetSdksFolder)/Microsoft.NET.Sdk.Publish/tools/netcoreapp1.0/Microsoft.NET.Sdk.Publish.Tasks.dll"
+    <Copy SourceFiles="$(WebSdkRoot)/bin/$(Configuration)/netcoreapp2.0/Microsoft.NET.Sdk.Publish.Tasks.dll"
+        DestinationFiles="$(DotNetSdksFolder)/Microsoft.NET.Sdk.Publish/tools/netcoreapp2.0/Microsoft.NET.Sdk.Publish.Tasks.dll"
+        OverwriteReadOnlyFiles="true" />
+
+    <!-- Copy Xdt assemblies -->
+    <Copy SourceFiles="$(WebSdkRoot)/bin/$(Configuration)/net46/win7-x86/Microsoft.Web.XmlTransform.dll"
+        DestinationFiles="$(DotNetSdksFolder)/Microsoft.NET.Sdk.Publish/tools/net46/Microsoft.Web.XmlTransform.dll"
+        OverwriteReadOnlyFiles="true" />
+
+    <Copy SourceFiles="$(WebSdkRoot)/bin/$(Configuration)/netcoreapp2.0/Microsoft.Web.XmlTransform.dll"
+        DestinationFiles="$(DotNetSdksFolder)/Microsoft.NET.Sdk.Publish/tools/netcoreapp2.0/Microsoft.Web.XmlTransform.dll"
         OverwriteReadOnlyFiles="true" />
 
   </Target>

--- a/dotnet-install_2.0.ps1
+++ b/dotnet-install_2.0.ps1
@@ -62,7 +62,7 @@
 [cmdletbinding()]
 param(
    [string]$Channel="master",
-   [string]$Version="2.1.300",
+   [string]$Version="2.1.302",
    [string]$InstallDir="<auto>",
    [string]$Architecture="<auto>",
    [switch]$SharedRuntime,

--- a/pack/Microsoft.NET.Sdk.Publish/Microsoft.NET.Sdk.Publish.csproj
+++ b/pack/Microsoft.NET.Sdk.Publish/Microsoft.NET.Sdk.Publish.csproj
@@ -9,7 +9,7 @@
   <Import Project="$(WebSdkRoot)\build\Version.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <OutputPath>$(WebSdkRoot)\bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>$(WebSdkRoot)\obj\$(Configuration)\</IntermediateOutputPath>
     <RuntimeIdenfier Condition="'$(RuntimeIdenfier)' == ''">win7-x86</RuntimeIdenfier>
@@ -22,15 +22,25 @@
       <PackagePath>tools\net46</PackagePath>
     </Content>
 
+    <Content Include="$(WebSdkRoot)\bin\$(Configuration)\net46\$(RuntimeIdenfier)\Microsoft.Web.XmlTransform.dll" Condition=" '$(DotNetBuildFromSource)' != 'true' ">
+      <Pack>true</Pack>
+      <PackagePath>tools\net46</PackagePath>
+    </Content>
+
     <!-- WebDeploy assemblies should be already signed.-->
     <Content Include="$(WebSdkBuild)\WebDeploy\**\*.*" Condition=" '$(DotNetBuildFromSource)' != 'true' ">
       <Pack>true</Pack>
       <PackagePath>tools\net46\%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
     </Content>
 
-    <Content Include="$(WebSdkRoot)\bin\$(Configuration)\netstandard1.3\Microsoft.NET.Sdk.Publish.Tasks.dll">
+    <Content Include="$(WebSdkRoot)\bin\$(Configuration)\netcoreapp2.0\Microsoft.NET.Sdk.Publish.Tasks.dll">
       <Pack>true</Pack>
-      <PackagePath>tools\netcoreapp1.0</PackagePath>
+      <PackagePath>tools\netcoreapp2.0</PackagePath>
+    </Content>
+
+    <Content Include="$(WebSdkRoot)\bin\$(Configuration)\netcoreapp2.0\Microsoft.Web.XmlTransform.dll">
+      <Pack>true</Pack>
+      <PackagePath>tools\netcoreapp2.0</PackagePath>
     </Content>
 
     <Content Include="$(WebSdkSource)\Publish\Microsoft.NET.Sdk.Publish.Targets\netstandard1.0\ComputeTargets\*.*">

--- a/pack/Microsoft.NET.Sdk.Web.ProjectSystem/Microsoft.NET.Sdk.Web.ProjectSystem.csproj
+++ b/pack/Microsoft.NET.Sdk.Web.ProjectSystem/Microsoft.NET.Sdk.Web.ProjectSystem.csproj
@@ -8,7 +8,7 @@
   <Import Project="$(WebSdkRoot)\build\Version.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <OutputPath>$(WebSdkRoot)\bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>$(WebSdkRoot)\obj\$(Configuration)\</IntermediateOutputPath>
   </PropertyGroup>

--- a/pack/Microsoft.NET.Sdk.Web/Microsoft.NET.Sdk.Web.csproj
+++ b/pack/Microsoft.NET.Sdk.Web/Microsoft.NET.Sdk.Web.csproj
@@ -8,7 +8,7 @@
   <Import Project="$(WebSdkRoot)\build\Version.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <OutputType>library</OutputType>
     <OutputPath>$(WebSdkRoot)\bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>$(WebSdkRoot)\obj\$(Configuration)\</IntermediateOutputPath>

--- a/src/Publish/Microsoft.NET.Sdk.Publish.Targets/netstandard1.0/Microsoft.NET.Sdk.Publish.targets
+++ b/src/Publish/Microsoft.NET.Sdk.Publish.Targets/netstandard1.0/Microsoft.NET.Sdk.Publish.targets
@@ -19,7 +19,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <!-- We want to force this property to be true, hence not adding a condition check -->
     <SupportsDeployOnBuild>true</SupportsDeployOnBuild>
-    <_PublishTaskFramework Condition=" '$(MSBuildRuntimeType)' == 'Core'">netcoreapp1.0</_PublishTaskFramework>
+    <_PublishTaskFramework Condition=" '$(MSBuildRuntimeType)' == 'Core'">netcoreapp2.0</_PublishTaskFramework>
     <_PublishTaskFramework Condition=" '$(_PublishTaskFramework)' == ''">net46</_PublishTaskFramework>
     <_PublishTasksDir Condition=" '$(_PublishTasksDir)'=='' ">$(MSBuildThisFileDirectory)..\..\tools\$(_PublishTaskFramework)\</_PublishTasksDir>
     <_PublishTaskAssemblyFullPath Condition=" '$(_PublishTaskAssemblyFullPath)'=='' ">$(_PublishTasksDir)Microsoft.NET.Sdk.Publish.Tasks.dll</_PublishTaskAssemblyFullPath>

--- a/src/Publish/Microsoft.NET.Sdk.Publish.Targets/netstandard1.0/TransformTargets/Microsoft.NET.Sdk.Publish.TransformFiles.targets
+++ b/src/Publish/Microsoft.NET.Sdk.Publish.Targets/netstandard1.0/TransformTargets/Microsoft.NET.Sdk.Publish.TransformFiles.targets
@@ -84,7 +84,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <PublishProfileName>$([System.IO.Path]::GetFileNameWithoutExtension($(WebPublishProfileFile)))</PublishProfileName>
   </PropertyGroup>
     
-    <!-- Run the transform at the config level e.g: web.Release.config-->
+    <!-- Run the transform at the config level e.g: web.Release.config if the configuration is Release-->
     <TransformXml Condition="Exists('$(MSBuildProjectDirectory)\web.$(Configuration).config')
                   And Exists('$(PublishIntermediateOutputPath)web.config')
                   And '$(RunXdt)' == 'true'"
@@ -95,7 +95,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                   SourceRootPath="$(PublishIntermediateOutputPath)"
                   TransformRootPath="$(MSBuildProjectDirectory)"/>
   
-      <!-- Run the transform at the profile level e.g: web.FolderProfile.config -->
+      <!-- Run the transform at the profile level e.g: web.FolderProfile.config if the profile name is FolderProfile -->
     <TransformXml Condition="Exists('$(MSBuildProjectDirectory)\web.$(PublishProfileName).config')
                   And Exists('$(PublishIntermediateOutputPath)web.config')
                   And '$(RunXdt)' == 'true'"
@@ -106,7 +106,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                   SourceRootPath="$(PublishIntermediateOutputPath)"
                   TransformRootPath="$(MSBuildProjectDirectory)"/>
   
-    <!-- Run the transform at the environment level e.g: web.staging.config -->
+    <!-- Run the transform at the environment level e.g: web.staging.config if the $(EnvironmentName) passed to msbuild is staging-->
     <TransformXml Condition="Exists('$(MSBuildProjectDirectory)\web.$(EnvironmentName).config')
                   And Exists('$(PublishIntermediateOutputPath)web.config')
                   And '$(RunXdt)' == 'true'"
@@ -118,7 +118,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                   TransformRootPath="$(MSBuildProjectDirectory)"/>
 
 
-    <!-- Run the custom transform file e.g: MyCustomTransformFile.xml -->
+    <!-- Run the custom transform file e.g: MyTransformFile.xml if the $(CustomTransformFileName) passed to msbuild is MyTransformFile.xml-->
     <TransformXml Condition=" $(CustomTransformFileName) != '' And Exists('$(MSBuildProjectDirectory)\$(CustomTransformFileName)')
                   And Exists('$(PublishIntermediateOutputPath)web.config')
                   And '$(RunXdt)' == 'true'"

--- a/src/Publish/Microsoft.NET.Sdk.Publish.Targets/netstandard1.0/TransformTargets/Microsoft.NET.Sdk.Publish.TransformFiles.targets
+++ b/src/Publish/Microsoft.NET.Sdk.Publish.Targets/netstandard1.0/TransformTargets/Microsoft.NET.Sdk.Publish.TransformFiles.targets
@@ -17,10 +17,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <UsingTask TaskName="TransformAppSettings" AssemblyFile="$(_PublishTaskAssemblyFullPath)"/>
   <UsingTask TaskName="GenerateEFSQLScripts" AssemblyFile="$(_PublishTaskAssemblyFullPath)"/>
   <UsingTask TaskName="GenerateRunCommandFile" AssemblyFile="$(_PublishTaskAssemblyFullPath)"/>
+    <UsingTask TaskName="TransformXml" AssemblyFile="$(_PublishTaskAssemblyFullPath)"/>
 
   <PropertyGroup>
     <_DotNetPublishTransformFiles>
       _TransformWebConfig;
+      _TransformXml;
       _TransformAppSettings;
       _GenerateEFSQLScripts;
       _GenerateRunCommandFile;
@@ -58,6 +60,51 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         AspNetCoreModuleName="$(AspNetCoreModuleName)"
         AspNetCoreHostingModel="$(AspNetCoreHostingModel)"
         EnvironmentName="$(EnvironmentName)"/> 
+  </Target>
+
+
+  <!--
+  ***********************************************************************************************
+  TARGET : _TransformXml
+  ***********************************************************************************************
+ -->
+  <Target Name="_TransformXml">
+    <PropertyGroup>
+      <TransformXmlStackTraceEnabled Condition="'$(TransformXmlStackTraceEnabled)' == ''">true</TransformXmlStackTraceEnabled>
+      <!-- Forcing the property value to be boolean -->
+      <TransformXmlStackTraceEnabled Condition="'$(TransformXmlStackTraceEnabled)' != 'true'">false</TransformXmlStackTraceEnabled>
+    </PropertyGroup>
+    
+  <PropertyGroup Condition="'$(WebPublishProfileFile)' !=''">
+    <PublishProfileName>$([System.IO.Path]::GetFileNameWithoutExtension($(WebPublishProfileFile)))</PublishProfileName>
+  </PropertyGroup>
+    
+    <!-- Run the transform at the config level -->
+    <TransformXml Condition="Exists('$(MSBuildProjectDirectory)\web.$(Configuration).config')"
+                  Source="$(PublishIntermediateOutputPath)web.config"
+                  Transform="$(MSBuildProjectDirectory)\web.$(Configuration).config"
+                  Destination="$(PublishIntermediateOutputPath)web.config"
+                  StackTrace="$(TransformXmlStackTraceEnabled)"
+                  SourceRootPath="$(PublishIntermediateOutputPath)"
+                  TransformRootPath="$(MSBuildProjectDirectory)"/>
+  
+      <!-- Run the transform at the profile level -->
+    <TransformXml Condition="Exists('$(MSBuildProjectDirectory)\web.$(PublishProfileName).config')"
+                  Source="$(PublishIntermediateOutputPath)web.config"
+                  Transform="$(MSBuildProjectDirectory)\web.$(PublishProfileName).config"
+                  Destination="$(PublishIntermediateOutputPath)web.config"
+                  StackTrace="$(TransformXmlStackTraceEnabled)"
+                  SourceRootPath="$(PublishIntermediateOutputPath)"
+                  TransformRootPath="$(MSBuildProjectDirectory)"/>
+  
+    <!-- Run the transform at the environment level -->
+    <TransformXml Condition="Exists('$(MSBuildProjectDirectory)\web.$(EnvironmentName).config')"
+                  Source="$(PublishIntermediateOutputPath)web.config"
+                  Transform="$(MSBuildProjectDirectory)\web.$(EnvironmentName).config"
+                  Destination="$(PublishIntermediateOutputPath)web.config"
+                  StackTrace="$(TransformXmlStackTraceEnabled)"
+                  SourceRootPath="$(PublishIntermediateOutputPath)"
+                  TransformRootPath="$(MSBuildProjectDirectory)"/>
   </Target>
 
   <!--

--- a/src/Publish/Microsoft.NET.Sdk.Publish.Targets/netstandard1.0/TransformTargets/Microsoft.NET.Sdk.Publish.TransformFiles.targets
+++ b/src/Publish/Microsoft.NET.Sdk.Publish.Targets/netstandard1.0/TransformTargets/Microsoft.NET.Sdk.Publish.TransformFiles.targets
@@ -69,18 +69,25 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   ***********************************************************************************************
  -->
   <Target Name="_TransformXml">
+
     <PropertyGroup>
+      <_IsAspNetCoreProject Condition="%(ProjectCapability.Identity) == 'AspNetCore'">true</_IsAspNetCoreProject>
       <TransformXmlStackTraceEnabled Condition="'$(TransformXmlStackTraceEnabled)' == ''">true</TransformXmlStackTraceEnabled>
       <!-- Forcing the property value to be boolean -->
       <TransformXmlStackTraceEnabled Condition="'$(TransformXmlStackTraceEnabled)' != 'true'">false</TransformXmlStackTraceEnabled>
+      <_WebConfigTransformCompleted Condition="'$(_IsAspNetCoreProject)' == 'true' And '$(IsTransformWebConfigDisabled)' != 'true' And '$(IsWebConfigTransformDisabled)' != 'true'">true</_WebConfigTransformCompleted>
+      <_WebConfigTransformCompleted Condition="'$(_WebConfigTransformCompleted)' == ''">false</_WebConfigTransformCompleted>
+      <RunXdt Condition="'$(RunXdt)' == ''">$(_WebConfigTransformCompleted)</RunXdt>
     </PropertyGroup>
     
   <PropertyGroup Condition="'$(WebPublishProfileFile)' !=''">
     <PublishProfileName>$([System.IO.Path]::GetFileNameWithoutExtension($(WebPublishProfileFile)))</PublishProfileName>
   </PropertyGroup>
     
-    <!-- Run the transform at the config level -->
-    <TransformXml Condition="Exists('$(MSBuildProjectDirectory)\web.$(Configuration).config')"
+    <!-- Run the transform at the config level e.g: web.Release.config-->
+    <TransformXml Condition="Exists('$(MSBuildProjectDirectory)\web.$(Configuration).config')
+                  And Exists('$(PublishIntermediateOutputPath)web.config')
+                  And '$(RunXdt)' == 'true'"
                   Source="$(PublishIntermediateOutputPath)web.config"
                   Transform="$(MSBuildProjectDirectory)\web.$(Configuration).config"
                   Destination="$(PublishIntermediateOutputPath)web.config"
@@ -88,8 +95,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                   SourceRootPath="$(PublishIntermediateOutputPath)"
                   TransformRootPath="$(MSBuildProjectDirectory)"/>
   
-      <!-- Run the transform at the profile level -->
-    <TransformXml Condition="Exists('$(MSBuildProjectDirectory)\web.$(PublishProfileName).config')"
+      <!-- Run the transform at the profile level e.g: web.FolderProfile.config -->
+    <TransformXml Condition="Exists('$(MSBuildProjectDirectory)\web.$(PublishProfileName).config')
+                  And Exists('$(PublishIntermediateOutputPath)web.config')
+                  And '$(RunXdt)' == 'true'"
                   Source="$(PublishIntermediateOutputPath)web.config"
                   Transform="$(MSBuildProjectDirectory)\web.$(PublishProfileName).config"
                   Destination="$(PublishIntermediateOutputPath)web.config"
@@ -97,10 +106,24 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                   SourceRootPath="$(PublishIntermediateOutputPath)"
                   TransformRootPath="$(MSBuildProjectDirectory)"/>
   
-    <!-- Run the transform at the environment level -->
-    <TransformXml Condition="Exists('$(MSBuildProjectDirectory)\web.$(EnvironmentName).config')"
+    <!-- Run the transform at the environment level e.g: web.staging.config -->
+    <TransformXml Condition="Exists('$(MSBuildProjectDirectory)\web.$(EnvironmentName).config')
+                  And Exists('$(PublishIntermediateOutputPath)web.config')
+                  And '$(RunXdt)' == 'true'"
                   Source="$(PublishIntermediateOutputPath)web.config"
                   Transform="$(MSBuildProjectDirectory)\web.$(EnvironmentName).config"
+                  Destination="$(PublishIntermediateOutputPath)web.config"
+                  StackTrace="$(TransformXmlStackTraceEnabled)"
+                  SourceRootPath="$(PublishIntermediateOutputPath)"
+                  TransformRootPath="$(MSBuildProjectDirectory)"/>
+
+
+    <!-- Run the custom transform file e.g: MyCustomTransformFile.xml -->
+    <TransformXml Condition=" $(CustomTransformFileName) != '' And Exists('$(MSBuildProjectDirectory)\$(CustomTransformFileName)')
+                  And Exists('$(PublishIntermediateOutputPath)web.config')
+                  And '$(RunXdt)' == 'true'"
+                  Source="$(PublishIntermediateOutputPath)web.config"
+                  Transform="$(MSBuildProjectDirectory)\$(CustomTransformFileName)"
                   Destination="$(PublishIntermediateOutputPath)web.config"
                   StackTrace="$(TransformXmlStackTraceEnabled)"
                   SourceRootPath="$(PublishIntermediateOutputPath)"

--- a/src/Publish/Microsoft.NET.Sdk.Publish.Tasks/Microsoft.NET.Sdk.Publish.Tasks.csproj
+++ b/src/Publish/Microsoft.NET.Sdk.Publish.Tasks/Microsoft.NET.Sdk.Publish.Tasks.csproj
@@ -7,11 +7,12 @@
   <Import Project="$(WebSdkRoot)\build\Version.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">netstandard1.3</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <OutputPath>$(WebSdkRoot)\bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>$(WebSdkRoot)\obj\$(Configuration)\</IntermediateOutputPath>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
     <RuntimeIdentifier>win7-x86</RuntimeIdentifier>
@@ -22,9 +23,10 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.1012" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Web.Xdt" Version="3.0.0-Preview1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
   </ItemGroup>

--- a/src/Publish/Microsoft.NET.Sdk.Publish.Tasks/Tasks/Xdt/TaskTransformationLogger.cs
+++ b/src/Publish/Microsoft.NET.Sdk.Publish.Tasks/Tasks/Xdt/TaskTransformationLogger.cs
@@ -1,0 +1,204 @@
+﻿using System;
+using System.Diagnostics;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.Web.XmlTransform;
+
+namespace Microsoft.NET.Sdk.Publish.Tasks.Xdt
+{
+    internal class TaskTransformationLogger : IXmlTransformationLogger
+    {
+        #region private data members
+        private TaskLoggingHelper loggingHelper;
+
+        private int indentLevel = 0;
+        private readonly string indentStringPiece = "  ";
+        private string indentString = null;
+
+        private bool stackTrace;
+        #endregion
+
+        public TaskTransformationLogger(TaskLoggingHelper loggingHelper)
+            : this(loggingHelper, false)
+        {
+        }
+
+        public TaskTransformationLogger(TaskLoggingHelper loggingHelper, bool stackTrace)
+        {
+            this.loggingHelper = loggingHelper;
+            this.stackTrace = stackTrace;
+        }
+
+        private string IndentString
+        {
+            get
+            {
+                if (indentString == null)
+                {
+                    indentString = String.Empty;
+                    for (int i = 0; i < indentLevel; i++)
+                    {
+                        indentString += indentStringPiece;
+                    }
+                }
+                return indentString;
+            }
+        }
+
+        private int IndentLevel
+        {
+            get
+            {
+                return indentLevel;
+            }
+            set
+            {
+                if (indentLevel != value)
+                {
+                    indentLevel = value;
+                    indentString = null;
+                }
+            }
+        }
+
+        #region IXmlTransformationLogger Members
+        void IXmlTransformationLogger.LogMessage(string message, params object[] messageArgs)
+        {
+            ((IXmlTransformationLogger)this).LogMessage(MessageType.Normal, message, messageArgs);
+        }
+
+        void IXmlTransformationLogger.LogMessage(MessageType type, string message, params object[] messageArgs)
+        {
+            MessageImportance importance;
+            switch (type)
+            {
+                case MessageType.Normal:
+                    importance = MessageImportance.Normal;
+                    break;
+                case MessageType.Verbose:
+                    importance = MessageImportance.Low;
+                    break;
+                default:
+                    Debug.Fail("Unknown MessageType");
+                    importance = MessageImportance.Normal;
+                    break;
+            }
+
+            loggingHelper.LogMessage(importance, String.Concat(IndentString, message), messageArgs);
+        }
+
+        void IXmlTransformationLogger.LogWarning(string message, params object[] messageArgs)
+        {
+            loggingHelper.LogWarning(message, messageArgs);
+        }
+
+        void IXmlTransformationLogger.LogWarning(string file, string message, params object[] messageArgs)
+        {
+            ((IXmlTransformationLogger)this).LogWarning(file, 0, 0, message, messageArgs);
+        }
+
+        void IXmlTransformationLogger.LogWarning(string file, int lineNumber, int linePosition, string message, params object[] messageArgs)
+        {
+            loggingHelper.LogWarning(
+                null,
+                null,
+                null,
+                file,
+                lineNumber,
+                linePosition,
+                0,
+                0,
+                loggingHelper.FormatString(message, messageArgs));
+        }
+
+        void IXmlTransformationLogger.LogError(string message, params object[] messageArgs)
+        {
+            loggingHelper.LogError(message, messageArgs);
+        }
+
+        void IXmlTransformationLogger.LogError(string file, string message, params object[] messageArgs)
+        {
+            ((IXmlTransformationLogger)this).LogError(file, 0, 0, message, messageArgs);
+        }
+
+        void IXmlTransformationLogger.LogError(string file, int lineNumber, int linePosition, string message, params object[] messageArgs)
+        {
+            loggingHelper.LogError(
+                null,
+                null,
+                null,
+                file,
+                lineNumber,
+                linePosition,
+                0,
+                0,
+                loggingHelper.FormatString(message, messageArgs));
+        }
+
+        void IXmlTransformationLogger.LogErrorFromException(Exception ex)
+        {
+            loggingHelper.LogErrorFromException(ex, stackTrace, stackTrace, null);
+        }
+
+        void IXmlTransformationLogger.LogErrorFromException(Exception ex, string file)
+        {
+            loggingHelper.LogErrorFromException(ex, stackTrace, stackTrace, file);
+        }
+
+        void IXmlTransformationLogger.LogErrorFromException(Exception ex, string file, int lineNumber, int linePosition)
+        {
+            string message = ex.Message;
+            if (stackTrace)
+            {
+                // loggingHelper.LogErrorFromException does not have an overload
+                // that accepts line numbers. So instead, we have to construct
+                // the error message from the exception and use LogError.
+                StringBuilder sb = new StringBuilder();
+                Exception exIterator = ex;
+                while (exIterator != null)
+                {
+                    sb.AppendFormat("{0} : {1}", exIterator.GetType().Name, exIterator.Message);
+                    sb.AppendLine();
+                    if (!String.IsNullOrEmpty(exIterator.StackTrace))
+                    {
+                        sb.Append(exIterator.StackTrace);
+                    }
+                    exIterator = exIterator.InnerException;
+                }
+
+                message = sb.ToString();
+            }
+
+            ((IXmlTransformationLogger)this).LogError(file, lineNumber, linePosition, message);
+        }
+
+        void IXmlTransformationLogger.StartSection(string message, params object[] messageArgs)
+        {
+            ((IXmlTransformationLogger)this).StartSection(MessageType.Normal, message, messageArgs);
+        }
+
+        void IXmlTransformationLogger.StartSection(MessageType type, string message, params object[] messageArgs)
+        {
+            ((IXmlTransformationLogger)this).LogMessage(type, message, messageArgs);
+            IndentLevel++;
+        }
+
+        void IXmlTransformationLogger.EndSection(string message, params object[] messageArgs)
+        {
+            ((IXmlTransformationLogger)this).EndSection(MessageType.Normal, message, messageArgs);
+        }
+
+        void IXmlTransformationLogger.EndSection(MessageType type, string message, params object[] messageArgs)
+        {
+            Debug.Assert(IndentLevel > 0);
+            if (IndentLevel > 0)
+            {
+                IndentLevel--;
+            }
+
+            ((IXmlTransformationLogger)this).LogMessage(type, message, messageArgs);
+        }
+        #endregion
+    }
+}

--- a/src/Publish/Microsoft.NET.Sdk.Publish.Tasks/Tasks/Xdt/TransformXml.cs
+++ b/src/Publish/Microsoft.NET.Sdk.Publish.Tasks/Tasks/Xdt/TransformXml.cs
@@ -90,24 +90,34 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Xdt
 
         public override bool Execute()
         {
+            return RunXmlTrasform();
+        }
+
+        public bool RunXmlTrasform(bool isLoggingEnabled = true)
+        {
             bool succeeded = true;
-            IXmlTransformationLogger logger = new TaskTransformationLogger(Log, StackTrace);
+            IXmlTransformationLogger logger = null;
+            if (isLoggingEnabled)
+            {
+                logger = new TaskTransformationLogger(Log, StackTrace);
+            }
+
             XmlTransformation transformation = null;
             XmlTransformableDocument document = null;
 
             try
             {
-                logger.StartSection(string.Format(System.Globalization.CultureInfo.CurrentCulture, Resources.BUILDTASK_TransformXml_TransformationStart, Source));
+                logger?.StartSection(string.Format(System.Globalization.CultureInfo.CurrentCulture, Resources.BUILDTASK_TransformXml_TransformationStart, Source));
                 document = OpenSourceFile(Source);
 
-                logger.LogMessage(string.Format(System.Globalization.CultureInfo.CurrentCulture, Resources.BUILDTASK_TransformXml_TransformationApply, Transform));
+                logger?.LogMessage(string.Format(System.Globalization.CultureInfo.CurrentCulture, Resources.BUILDTASK_TransformXml_TransformationApply, Transform));
                 transformation = OpenTransformFile(Transform, logger);
 
                 succeeded = transformation.Apply(document);
 
                 if (succeeded)
                 {
-                    logger.LogMessage(string.Format(System.Globalization.CultureInfo.CurrentCulture, Resources.BUILDTASK_TransformXml_TransformOutput, Destination));
+                    logger?.LogMessage(string.Format(System.Globalization.CultureInfo.CurrentCulture, Resources.BUILDTASK_TransformXml_TransformOutput, Destination));
 
                     SaveTransformedFile(document, Destination);
                 }
@@ -121,17 +131,17 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Xdt
                     localPath = sourceUri.LocalPath;
                 }
 
-                logger.LogError(localPath, ex.LineNumber, ex.LinePosition, ex.Message);
+                logger?.LogError(localPath, ex.LineNumber, ex.LinePosition, ex.Message);
                 succeeded = false;
             }
             catch (Exception ex)
             {
-                logger.LogErrorFromException(ex);
+                logger?.LogErrorFromException(ex);
                 succeeded = false;
             }
             finally
             {
-                logger.EndSection(string.Format(System.Globalization.CultureInfo.CurrentCulture, succeeded ?
+                logger?.EndSection(string.Format(System.Globalization.CultureInfo.CurrentCulture, succeeded ?
                     Resources.BUILDTASK_TransformXml_TransformationSucceeded :
                     Resources.BUILDTASK_TransformXml_TransformationFailed));
                 if (transformation != null)

--- a/src/Publish/Microsoft.NET.Sdk.Publish.Tasks/Tasks/Xdt/TransformXml.cs
+++ b/src/Publish/Microsoft.NET.Sdk.Publish.Tasks/Tasks/Xdt/TransformXml.cs
@@ -1,0 +1,209 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.NET.Sdk.Publish.Tasks.MsDeploy;
+using Microsoft.NET.Sdk.Publish.Tasks.Properties;
+using Microsoft.Web.XmlTransform;
+using System;
+
+namespace Microsoft.NET.Sdk.Publish.Tasks.Xdt
+{
+    public class TransformXml : Task
+    {
+        private string _sourceFile = null;
+        private string _transformFile = null;
+        private string _destinationFile = null;
+        private string _sourceRootPath = string.Empty;
+        private string _transformRootPath = string.Empty;
+        private bool stackTrace = false;
+
+        [Required]
+        public String Source
+        {
+            get
+            {
+                return Utility.GetFilePathResolution(_sourceFile, SourceRootPath);
+            }
+            set { _sourceFile = value; }
+        }
+
+        public string SourceRootPath
+        {
+            get { return _sourceRootPath; }
+            set { _sourceRootPath = value; }
+        }
+
+
+        [Required]
+        public String Transform
+        {
+            get
+            {
+                return Utility.GetFilePathResolution(_transformFile, TransformRootPath);
+            }
+            set
+            {
+                _transformFile = value;
+            }
+        }
+
+        public string TransformRootPath
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_transformRootPath))
+                {
+                    return this.SourceRootPath;
+                }
+                else
+                {
+                    return _transformRootPath;
+                }
+            }
+            set { _transformRootPath = value; }
+        }
+
+
+        [Required]
+        public String Destination
+        {
+            get
+            {
+                return _destinationFile;
+            }
+            set
+            {
+                _destinationFile = value;
+            }
+        }
+
+        public bool StackTrace
+        {
+            get
+            {
+                return stackTrace;
+            }
+            set
+            {
+                stackTrace = value;
+            }
+        }
+
+        public override bool Execute()
+        {
+            bool succeeded = true;
+            IXmlTransformationLogger logger = new TaskTransformationLogger(Log, StackTrace);
+            XmlTransformation transformation = null;
+            XmlTransformableDocument document = null;
+
+            try
+            {
+                logger.StartSection(string.Format(System.Globalization.CultureInfo.CurrentCulture, Resources.BUILDTASK_TransformXml_TransformationStart, Source));
+                document = OpenSourceFile(Source);
+
+                logger.LogMessage(string.Format(System.Globalization.CultureInfo.CurrentCulture, Resources.BUILDTASK_TransformXml_TransformationApply, Transform));
+                transformation = OpenTransformFile(Transform, logger);
+
+                succeeded = transformation.Apply(document);
+
+                if (succeeded)
+                {
+                    logger.LogMessage(string.Format(System.Globalization.CultureInfo.CurrentCulture, Resources.BUILDTASK_TransformXml_TransformOutput, Destination));
+
+                    SaveTransformedFile(document, Destination);
+                }
+            }
+            catch (System.Xml.XmlException ex)
+            {
+                string localPath = Source;
+                if (!string.IsNullOrEmpty(ex.SourceUri))
+                {
+                    Uri sourceUri = new Uri(ex.SourceUri);
+                    localPath = sourceUri.LocalPath;
+                }
+
+                logger.LogError(localPath, ex.LineNumber, ex.LinePosition, ex.Message);
+                succeeded = false;
+            }
+            catch (Exception ex)
+            {
+                logger.LogErrorFromException(ex);
+                succeeded = false;
+            }
+            finally
+            {
+                logger.EndSection(string.Format(System.Globalization.CultureInfo.CurrentCulture, succeeded ?
+                    Resources.BUILDTASK_TransformXml_TransformationSucceeded :
+                    Resources.BUILDTASK_TransformXml_TransformationFailed));
+                if (transformation != null)
+                {
+                    transformation.Dispose();
+                }
+                if (document != null)
+                {
+                    document.Dispose();
+                }
+            }
+
+            return succeeded;
+        }
+
+        private void SaveTransformedFile(XmlTransformableDocument document, string destinationFile)
+        {
+            try
+            {
+                document.Save(destinationFile);
+            }
+            catch (System.Xml.XmlException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(
+                    string.Format(System.Globalization.CultureInfo.CurrentCulture, Resources.BUILDTASK_TransformXml_DestinationWriteFailed, ex.Message),
+                    ex);
+            }
+        }
+
+        private XmlTransformableDocument OpenSourceFile(string sourceFile)
+        {
+            try
+            {
+                XmlTransformableDocument document = new XmlTransformableDocument();
+
+                document.PreserveWhitespace = true;
+                document.Load(sourceFile);
+
+                return document;
+            }
+            catch (System.Xml.XmlException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(
+                    string.Format(System.Globalization.CultureInfo.CurrentCulture, Resources.BUILDTASK_TransformXml_SourceLoadFailed, ex.Message),
+                    ex);
+            }
+        }
+
+        private XmlTransformation OpenTransformFile(string transformFile, IXmlTransformationLogger logger)
+        {
+            try
+            {
+                return new XmlTransformation(transformFile, logger);
+            }
+            catch (System.Xml.XmlException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(
+                    string.Format(System.Globalization.CultureInfo.CurrentCulture, Resources.BUILDTASK_TransformXml_TransformLoadFailed, ex.Message),
+                    ex);
+            }
+        }
+    }
+}

--- a/test/Publish/Microsoft.NET.Sdk.Publish.Tasks.Tests/Tasks/TransformXmlTests.cs
+++ b/test/Publish/Microsoft.NET.Sdk.Publish.Tasks.Tests/Tasks/TransformXmlTests.cs
@@ -1,0 +1,141 @@
+﻿using Microsoft.NET.Sdk.Publish.Tasks.Xdt;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Xunit;
+
+namespace Microsoft.NET.Sdk.Publish.Tasks.Tests.Tasks
+{
+    public class TransformXmlTests
+    {
+        private XDocument _webConfigTemplate => XDocument.Parse(
+@"<configuration>
+  <location path=""."" inheritInChildApplications=""false"">
+      <system.webServer>
+        <handlers>
+          <add name=""aspNetCore"" path=""*"" verb=""*"" modules=""AspNetCoreModule"" resourceType=""Unspecified""/>
+        </handlers>
+        <aspNetCore processPath=""dotnet"" arguments="".\test.dll"" stdoutLogEnabled=""false"" stdoutLogFile="".\logs\stdout"">
+          <environmentVariables />
+        </aspNetCore>
+      </system.webServer>
+  </location >
+</configuration>");
+
+        private XDocument _webConfigTransformRemoveAll => XDocument.Parse(
+@"<configuration xmlns:xdt=""http://schemas.microsoft.com/XML-Document-Transform"">
+  <location>
+      <system.webServer>
+        <handlers xdt:Transform=""RemoveAll"" />
+        <aspNetCore xdt:Transform=""RemoveAll"" />
+      </system.webServer>
+  </location >
+</configuration>");
+
+
+        private XDocument _webConfigTransformAdd => XDocument.Parse(
+@"<configuration xmlns:xdt=""http://schemas.microsoft.com/XML-Document-Transform"">
+  <location>
+      <system.webServer>
+        <aspNetCore>
+          <environmentVariables>
+            <environmentVariable name=""MyCustomEnvVariable"" value=""MyCustomValue"" xdt:Transform=""Insert"" />
+          </environmentVariables>
+        </aspNetCore>
+      </system.webServer>
+  </location >
+</configuration>");
+
+
+        [Fact]
+        public void XmlTransform_AppliesRemoveAllTransform()
+        {
+            // Arrange
+            string sourceFile = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
+            string transformFile = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
+            string outputFile = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
+
+            try
+            {
+                _webConfigTemplate.Save(sourceFile);
+                _webConfigTransformRemoveAll.Save(transformFile);
+
+                // Act
+                TransformXml transformTask = new TransformXml()
+                {
+                    Source = sourceFile,
+                    Destination = outputFile,
+                    Transform = transformFile,
+                    SourceRootPath = Path.GetTempPath(),
+                    TransformRootPath = Path.GetTempPath(),
+                    StackTrace = true
+                };
+
+                bool success = transformTask.RunXmlTrasform(isLoggingEnabled: false);
+
+
+                // Assert
+                Assert.True(success);
+                Assert.True(XDocument.Parse(File.ReadAllText(sourceFile)).Descendants("handlers").Count() == 1);
+                Assert.True(XDocument.Parse(File.ReadAllText(sourceFile)).Descendants("aspNetCore").Count() == 1);
+
+                Assert.True(XDocument.Parse(File.ReadAllText(outputFile)).Descendants("handlers").Count() == 0);
+                Assert.True(XDocument.Parse(File.ReadAllText(outputFile)).Descendants("aspNetCore").Count() == 0);
+            }
+            finally
+            {
+                File.Delete(sourceFile);
+                File.Delete(transformFile);
+                File.Delete(outputFile);
+            }
+
+        }
+
+
+        [Fact]
+        public void XmlTransform_AppliesAdd()
+        {
+            // Arrange
+            string sourceFile = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
+            string transformFile = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
+            string outputFile = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
+
+            try
+            {
+                _webConfigTemplate.Save(sourceFile);
+                _webConfigTransformAdd.Save(transformFile);
+
+                // Act
+                TransformXml transformTask = new TransformXml()
+                {
+                    Source = sourceFile,
+                    Destination = outputFile,
+                    Transform = transformFile,
+                    SourceRootPath = Path.GetTempPath(),
+                    TransformRootPath = Path.GetTempPath(),
+                    StackTrace = true
+                };
+
+                bool success = transformTask.RunXmlTrasform(isLoggingEnabled: false);
+
+
+                // Assert
+                Assert.True(success);
+                Assert.True(XDocument.Parse(File.ReadAllText(sourceFile)).Descendants("environmentVariable").Count() == 0);
+                Assert.True(XDocument.Parse(File.ReadAllText(outputFile)).Descendants("environmentVariable").Count() == 1);
+            }
+            finally
+            {
+                File.Delete(sourceFile);
+                File.Delete(transformFile);
+                File.Delete(outputFile);
+            }
+
+        }
+
+    }
+}


### PR DESCRIPTION
Xml transforms are supported at 4 levels - Configuration, Profile, Environment & Custom.

1. Configuration specific transform : web.$(configuration).config
  - Adding a web.$(configuration).config to the root of the project.
  - This is the first transform that gets run.


2. Profile specific transform : web.`<profilename>`.config - msbuild property for profilename is $(PublishProfile)
  - Adding a web.`<profilename>`.config to the root of the project.
  - This is the second transform that gets run.
 - The profile name here is the name of the profile used. If no profile is passed, then the default profile name is 'FileSystem' (i.e web.FileSystem.config will be applied if present )


3. Environment specific transform: web.$(EnvironmentName).config
  - Adding a web.$(EnvironmentName).config to the root of the project.
  - This is the third transform that gets run.
 - EnvironmentName can be specified from the commandline or pubxml. When Environment name is specified, Web config transform will automatically add this environment variable in the web.config (ASPNETCORE_ENVIRONMENT).

4. Custom transform : <Any file name>
- Adding any transform file to the root of the project and setting the msbuild property $(CustomTransformFileName) to the name of the transform file.
- This is the last transform that gets run.




