### PR TITLE
Fix typo in error message

### DIFF
--- a/src/Publish/Microsoft.NET.Sdk.Publish.Tasks/Properties/Resources.Designer.cs
+++ b/src/Publish/Microsoft.NET.Sdk.Publish.Tasks/Properties/Resources.Designer.cs
@@ -1781,7 +1781,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to In process hosting is not supported for AspNetCoreModule. Change the AspNetCoreModule to atleast AspNetCoreModuleV2..
+        ///   Looks up a localized string similar to In process hosting is not supported for AspNetCoreModule. Change the AspNetCoreModule to at least AspNetCoreModuleV2..
         /// </summary>
         public static string WebConfigTransform_InvalidHostingOption {
             get {

--- a/src/Publish/Microsoft.NET.Sdk.Publish.Tasks/Properties/Resources.resx
+++ b/src/Publish/Microsoft.NET.Sdk.Publish.Tasks/Properties/Resources.resx
@@ -1153,6 +1153,6 @@ For more information on this deploy script visit:	https://go.microsoft.com/fwlin
     <value>The acceptable value for AspNetCoreModuleHostingModel property is either "InProcess" or "OutOfProcess".</value>
   </data>
   <data name="WebConfigTransform_InvalidHostingOption" xml:space="preserve">
-    <value>In process hosting is not supported for AspNetCoreModule. Change the AspNetCoreModule to atleast AspNetCoreModuleV2.</value>
+    <value>In process hosting is not supported for AspNetCoreModule. Change the AspNetCoreModule to at least AspNetCoreModuleV2.</value>
   </data>
 </root>


### PR DESCRIPTION
Fix typo in the `WebConfigTransform_InvalidHostingOption` resource string.