### PR TITLE
Add property to disable Web SDK implicit version logic

### DIFF
--- a/src/Web/Microsoft.NET.Sdk.Web.Targets/Sdk.targets
+++ b/src/Web/Microsoft.NET.Sdk.Web.Targets/Sdk.targets
@@ -19,6 +19,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.targets" />
 
-  <Import Project="$(MSBuildThisFileDirectory)Sdk.DefaultItems.targets" />
+  <PropertyGroup Condition="'$(EnableWebSdkImplicitPackageVersions)' == ''">
+    <EnableWebSdkImplicitPackageVersions>true</EnableWebSdkImplicitPackageVersions>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)Sdk.DefaultItems.targets" Condition="'$(EnableWebSdkImplicitPackageVersions)' == 'true'"/>
 
 </Project>


### PR DESCRIPTION
We would like to move the implicit package version selection logic to the .NET SDK.  This PR adds a property which allows disabling the logic in the Web SDK, which the .NET SDK can then set in order to use its own logic.

See https://github.com/dotnet/sdk/pull/2533