### PR TITLE
[release/2.1.5xx] Use roslyn-tools technique to skip test restore

### DIFF
--- a/build/Empty.targets
+++ b/build/Empty.targets
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<!-- Copied from https://github.com/dotnet/roslyn-tools/blob/c442fe46e02b31e3954a7c669cc309a8b0175115/sdks/RepoToolset/tools/Empty.targets -->
+<Project DefaultTargets="Build">
+
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <!--
+    Import this file to suppress all targets while allowing the project to participate in the build.
+    Workaround for https://github.com/dotnet/sdk/issues/2071.
+    
+    The targets defined here are not sufficient for the project to be open in Visual Studio without issues though.    
+  -->
+
+  <Target Name="_IsProjectRestoreSupported"/>
+  <Target Name="Restore"/>
+  <Target Name="Build"/>
+  <Target Name="Test"/>
+  <Target Name="Pack"/>
+
+</Project>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <!-- Projects in this directory are test-related, and shouldn't participate in source-build. -->
+  <PropertyGroup>
+    <_SuppressAllTargets>false</_SuppressAllTargets>
+    <_SuppressAllTargets Condition="'$(DotNetBuildFromSource)' == 'true'">true</_SuppressAllTargets>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\build\Empty.targets" Condition="$(_SuppressAllTargets)"/>
+</Project>


### PR DESCRIPTION
This is a patch for removing test dependencies from source-build: https://github.com/dotnet/source-build/pull/847.

I copied the approach RepoToolset takes: the same build command still runs (which I believe uses the solution file), but test project restore/build targets are overridden with blank ones.

@mlorbetske, PTAL.