### PR TITLE
Add AppServicePublish capability to core web apps

### DIFF
--- a/src/ProjectSystem/Microsoft.NET.Sdk.Web.ProjectSystem.Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.targets
+++ b/src/ProjectSystem/Microsoft.NET.Sdk.Web.ProjectSystem.Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.targets
@@ -29,6 +29,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ProjectCapability Include="DotNetCoreWeb" />
     <ProjectCapability Include="AspNetCore" />
     <ProjectCapability Include="Web" />
+    <ProjectCapability Include="AppServicePublish" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' != '' And '$(_TargetFrameworkVersionWithoutV)' &gt;= '3.0' ">


### PR DESCRIPTION
@vijayrkn  Adding AppServicePublish capability to web core projects (assuming Publish and FolderPublish capabilities are coming from core sdk and we inherit them)