### PR TITLE
Lowercase the hostingModel attribute value

### DIFF
--- a/src/Publish/Tasks/WebConfigTransform.cs
+++ b/src/Publish/Tasks/WebConfigTransform.cs
@@ -157,10 +157,10 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
                         {
                             throw new Exception(Resources.WebConfigTransform_InvalidHostingOption);
                         }
-                        aspNetCoreElement.SetAttributeValue("hostingModel", aspNetCoreHostingModel);
+                        aspNetCoreElement.SetAttributeValue("hostingModel", aspNetCoreHostingModel.ToLowerInvariant());
                         break;
                     case "OUTOFPROCESS":
-                        aspNetCoreElement.SetAttributeValue("hostingModel", aspNetCoreHostingModel);
+                        aspNetCoreElement.SetAttributeValue("hostingModel", aspNetCoreHostingModel.ToLowerInvariant());
                         break;
                     default:
                         throw new Exception(Resources.WebConfigTransform_HostingModel_Error);


### PR DESCRIPTION
Perhaps, I should've opened an issue; but if this is *the fix*, it's quicker to put this up as a quick patch.

I noticed a warning while working with a local *web.config* and IIS Express in VS:

> The 'hostingModel' attribute is invalid - The value 'InProcess' is invalid according to its datatype 'String' - The Enumeration constraint failed.

Then, I noticed that the `hostingModel` attribute value was Pascal cased in the local *web.config*:

```xml
<aspNetCore processPath="%LAUNCHER_PATH%" 
            arguments="%LAUNCHER_ARGS%"
            stdoutLogEnabled="true" 
            stdoutLogFile=".\logs\stdout"
            hostingModel="InProcess">
```

When I change it to `hostingModel="inprocess"`, that warning goes away.

I checked the aspnet/AspNetCore repo to see how it has been composed there in samples/examples/tests, and it's lowercase everywhere ([here's one example](https://github.com/aspnet/AspNetCore/blob/master/src/Servers/IIS/IIS/samples/NativeIISSample/web.config)). Therefore, I assume it would be good to lowercase it on *web.config* generation because if the project file contains ...

```xml
<AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
```

... it publishes with Pascal casing. If the property value is `inprocess`, it publishes lowercase, but we document the property with Pascal casing, and the templates use Pascal casing.