### PR TITLE
Fixing the publish issue in TRK

### DIFF
--- a/src/Publish/Microsoft.NET.Sdk.Publish.Tasks/WebConfigTransform.cs
+++ b/src/Publish/Microsoft.NET.Sdk.Publish.Tasks/WebConfigTransform.cs
@@ -150,9 +150,9 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
             // Set the hostingmodel attribute only if it is not already set in the web.config and AspNetCoreHostingModel property is set.
             if (hostingModelAttributeValue == null && !string.IsNullOrEmpty(aspNetCoreHostingModel))
             {
-                switch(aspNetCoreHostingModel.ToLower())
+                switch(aspNetCoreHostingModel.ToUpperInvariant())
                 {
-                    case "inprocess":
+                    case "INPROCESS":
                         // In process is not supported for AspNetCoreModule.
                         if (string.Equals(aspNetCoreModuleName, "AspNetCoreModule", StringComparison.OrdinalIgnoreCase))
                         {
@@ -160,7 +160,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
                         }
                         aspNetCoreElement.SetAttributeValue("hostingModel", aspNetCoreHostingModel);
                         break;
-                    case "outofprocess":
+                    case "OUTOFPROCESS":
                         aspNetCoreElement.SetAttributeValue("hostingModel", aspNetCoreHostingModel);
                         break;
                     default:


### PR DESCRIPTION
https://github.com/aspnet/websdk/issues/437

Issue: 
Publish fails in TRK builds with the following error 

The ‘TransformWebConfig’ task failed unexpectedly-The acceptable value for AspNetCoreModuleHostingModel property is either 'InProcess' or 'OutOfProcess'".

Root Cause:
String Comparison was done without the InVariant call.

Fix: 
Add InvariantStringComparison

Risk: 
Very Low

Impact:
Publish users using TRK builds are impacted.