### PR TITLE
Update the hosting model in web.config in all cases

### DIFF
--- a/src/Publish/Tasks/Tasks/TransformWebConfig.cs
+++ b/src/Publish/Tasks/Tasks/TransformWebConfig.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Xml;
 using System.Xml.Linq;
 using Microsoft.Build.Framework;
@@ -99,7 +99,16 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
             }
 
             string outputFile = Path.GetFileName(TargetPath);
-            XDocument transformedConfig = WebConfigTransform.Transform(webConfigXml, outputFile, IsAzure, UseAppHost, ExecutableExtension, AspNetCoreModuleName, AspNetCoreHostingModel, EnvironmentName);
+            XDocument transformedConfig = WebConfigTransform.Transform(
+                webConfigXml,
+                outputFile,
+                IsAzure,
+                UseAppHost,
+                ExecutableExtension,
+                AspNetCoreModuleName,
+                AspNetCoreHostingModel,
+                EnvironmentName,
+                ProjectFullPath);
 
             // Telemetry
             transformedConfig = WebConfigTelemetry.AddTelemetry(transformedConfig, ProjectGuid, IgnoreProjectGuid, SolutionPath, ProjectFullPath);

--- a/src/Publish/Tasks/WebConfigTransform.cs
+++ b/src/Publish/Tasks/WebConfigTransform.cs
@@ -90,7 +90,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
             SetAttributeValueIfEmpty(aspNetCoreElement, "resourceType", "Unspecified");
         }
 
-        private static void TransformAspNetCore(XElement aspNetCoreElement, string appName, bool configureForAzure, bool useAppHost, string extension, string aspNetCoreModuleName, string aspNetCoreHostingModel, string projectFullPath)
+        private static void TransformAspNetCore(XElement aspNetCoreElement, string appName, bool configureForAzure, bool useAppHost, string extension, string aspNetCoreModuleName, string aspNetCoreHostingModelValue, string projectFullPath)
         {
             // Forward slashes currently work neither in AspNetCoreModule nor in dotnet so they need to be
             // replaced with backwards slashes when the application is published on a non-Windows machine
@@ -156,24 +156,24 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
 
             if (File.Exists(projectWebConfigPath))
             {
-                // Set the hostingmodel attribute only if it is not already set in the web.config and AspNetCoreHostingModel property is set.
+                // Set the hostingmodel attribute only if it not already set in the project's web.config.
                 if (hostingModelAttributeValue == null)
                 {
-                    SetAspNetCoreHostingModel(aspNetCoreHostingModel, aspNetCoreModuleName, aspNetCoreElement);
+                    SetAspNetCoreHostingModel(aspNetCoreHostingModelValue, aspNetCoreModuleName, aspNetCoreElement);
                 }
             }
             else
             {
-                SetAspNetCoreHostingModel(aspNetCoreHostingModel, aspNetCoreModuleName, aspNetCoreElement);
+                SetAspNetCoreHostingModel(aspNetCoreHostingModelValue, aspNetCoreModuleName, aspNetCoreElement);
             }
         }
 
 
-        private static void SetAspNetCoreHostingModel(string aspNetCoreHostingModel, string aspNetCoreModuleName, XElement aspNetCoreElement)
+        private static void SetAspNetCoreHostingModel(string aspNetCoreHostingModelValue, string aspNetCoreModuleName, XElement aspNetCoreElement)
         {
-            if (!string.IsNullOrEmpty(aspNetCoreHostingModel))
+            if (!string.IsNullOrEmpty(aspNetCoreHostingModelValue))
             {
-                switch (aspNetCoreHostingModel.ToUpperInvariant())
+                switch (aspNetCoreHostingModelValue.ToUpperInvariant())
                 {
                     case "INPROCESS":
                         // In process is not supported for AspNetCoreModule.
@@ -181,10 +181,10 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
                         {
                             throw new Exception(Resources.WebConfigTransform_InvalidHostingOption);
                         }
-                        aspNetCoreElement.SetAttributeValue("hostingModel", aspNetCoreHostingModel);
+                        aspNetCoreElement.SetAttributeValue("hostingModel", aspNetCoreHostingModelValue);
                         break;
                     case "OUTOFPROCESS":
-                        aspNetCoreElement.SetAttributeValue("hostingModel", aspNetCoreHostingModel);
+                        aspNetCoreElement.SetAttributeValue("hostingModel", aspNetCoreHostingModelValue);
                         break;
                     default:
                         throw new Exception(Resources.WebConfigTransform_HostingModel_Error);

--- a/test/Publish/Tasks/WebConfigTelemetryTests.cs
+++ b/test/Publish/Tasks/WebConfigTelemetryTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Tests
         public void WebConfigTelemetry_DoesNotSetProjectGuidIfOptedOut_ThroughIgnoreProjectGuid(string projectGuid)
         {
             // Arrange
-            XDocument transformedWebConfig = WebConfigTransform.Transform(null, "test.exe", configureForAzure: false, useAppHost: true, extension: ".exe", aspNetCoreModuleName: null, aspNetCoreHostingModel:null, environmentName: null);
+            XDocument transformedWebConfig = WebConfigTransform.Transform(null, "test.exe", configureForAzure: false, useAppHost: true, extension: ".exe", aspNetCoreModuleName: null, aspNetCoreHostingModel:null, environmentName: null, projectFullPath: null);
             Assert.True(XNode.DeepEquals(WebConfigTransformTemplates.WebConfigTemplate, transformedWebConfig));
 
             //Act 


### PR DESCRIPTION
- If the publish folder is not removed & project file is updated with new hosting model, then published web.config is not updated. 

This is because the earlier logic assumes that web.config present in the published folder is always from project. This assumption is wrong. 

If the publish output folder is not removed, then it might have a web.config from the previous run. 

Fix: Check for the existence of web.config in the project before doing this check.