### PR TITLE
Make schema available for TypeScript items when using TypeScript NuGet

### DIFF
--- a/src/ProjectSystem/Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.targets
+++ b/src/ProjectSystem/Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.targets
@@ -15,7 +15,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.targets') AND '$(EnableTypeScriptNuGetTarget)' != 'true'"/>
 
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.DotNetCore.targets"
-          Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.DotNetCore.targets') AND '$(EnableTypeScriptNuGetTarget)' != 'true'"/>
+          Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.DotNetCore.targets')"/>
 
   <PropertyGroup>
     <EnableDefaultContentItems Condition=" '$(EnableDefaultContentItems)' == '' ">true</EnableDefaultContentItems>


### PR DESCRIPTION
The schema for TypeScript items allows the IDE to display TypeScript items (.ts files) correctly in the hierarchy. The Web.ProjectSystem SDK targets imports the schema for TypeScript items as long as the TypeScript targets being referenced are not from the Microsoft.TypeScript.MSBuild NuGet package (that is, if TypeScript comes from the TS SDK instead). However, the TypeScript NuGet package doesn't actually contain the schema itself. So when a user installs the NuGet package in their project, the .ts files will disappear, This PR makes the reference to the schema unconditional.