### PR TITLE
Onboard with async publishing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,10 @@ variables:
   # Cannot use key:value syntax in root defined variables
   - name: _TeamName
     value: DotNetCore
+  - name: _PublishUsingPipelines
+    value: true
+  - name: _DotNetArtifactsCategory
+    value: .NETCore
 
 resources:
   containers:
@@ -26,6 +30,7 @@ jobs:
     enablePublishBuildArtifacts: true
     enablePublishTestResults: true
     enablePublishBuildAssets: true
+    enablePublishUsingPipelines: $(_PublishUsingPipelines)
     enableTelemetry: true
     helixRepo: aspnet/websdk
     jobs:
@@ -57,6 +62,8 @@ jobs:
             /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
             /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)
             /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
+            /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+            /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
             /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
             /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
             /p:OfficialBuildId=$(BUILD.BUILDNUMBER)


### PR DESCRIPTION
Relates to: https://github.com/dotnet/arcade/issues/2443

Goal: mitigate `lock on the feed problem` and add further validations. [More details here.](https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/AsyncPublishing_HowToUse.md)

Test build was here: https://dev.azure.com/dnceng/7ea9116e-9fac-403d-b258-b31fcf1bb293/_build/index?buildId=149732
Test release: https://dev.azure.com/dnceng/internal/_apps/hub/ms.vss-releaseManagement-web.cd-release-progress?_a=release-pipeline-progress&releaseId=4447