### PR TITLE
Adding support for Env transform in web.config

### DIFF
--- a/src/Publish/Package/Microsoft.NET.Sdk.Publish.csproj
+++ b/src/Publish/Package/Microsoft.NET.Sdk.Publish.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <PublishRoot Condition="'$(PublishRoot)' == ''">$(RepoRoot)\src\Publish\</PublishRoot>
+    <!-- The transform file is used by the publish process -->
+    <NoWarn>NU5108</NoWarn>
   </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)\Package.props" />
@@ -53,3 +55,4 @@
   </ItemGroup>
 
 </Project>
+

--- a/src/Publish/Targets/TransformTargets/Microsoft.NET.Sdk.Publish.TransformFiles.targets
+++ b/src/Publish/Targets/TransformTargets/Microsoft.NET.Sdk.Publish.TransformFiles.targets
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
 ***********************************************************************************************
 Microsoft.NET.Sdk.Publish.TransformFiles.targets
 
@@ -17,7 +17,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <UsingTask TaskName="TransformAppSettings" AssemblyFile="$(_PublishTaskAssemblyFullPath)"/>
   <UsingTask TaskName="GenerateEFSQLScripts" AssemblyFile="$(_PublishTaskAssemblyFullPath)"/>
   <UsingTask TaskName="GenerateRunCommandFile" AssemblyFile="$(_PublishTaskAssemblyFullPath)"/>
-    <UsingTask TaskName="TransformXml" AssemblyFile="$(_PublishTaskAssemblyFullPath)"/>
+  <UsingTask TaskName="TransformXml" AssemblyFile="$(_PublishTaskAssemblyFullPath)"/>
+  <UsingTask TaskName="GenerateEnvTransform" AssemblyFile="$(_PublishTaskAssemblyFullPath)"/>
 
   <PropertyGroup>
     <_DotNetPublishTransformFiles>
@@ -119,7 +120,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
 
     <!-- Run the custom transform file e.g: MyTransformFile.xml if the $(CustomTransformFileName) passed to msbuild is MyTransformFile.xml-->
-    <TransformXml Condition=" $(CustomTransformFileName) != '' And Exists('$(MSBuildProjectDirectory)\$(CustomTransformFileName)')
+    <TransformXml Condition=" '$(CustomTransformFileName)' != ''
+                  And Exists('$(MSBuildProjectDirectory)\$(CustomTransformFileName)')
                   And Exists('$(PublishIntermediateOutputPath)web.config')
                   And '$(RunXdt)' == 'true'"
                   Source="$(PublishIntermediateOutputPath)web.config"
@@ -128,6 +130,42 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                   StackTrace="$(TransformXmlStackTraceEnabled)"
                   SourceRootPath="$(PublishIntermediateOutputPath)"
                   TransformRootPath="$(MSBuildProjectDirectory)"/>
+
+    <!-- Run the custom transform file from any location e.g: c:\temp\MyTransformFile.xml if the $(CustomTransformFileName) passed to msbuild is MyTransformFile.xml
+    and $(CustomTransformFilePath) passed to msbuild is c:\temp\-->
+    <TransformXml Condition=" '$(CustomTransformFileName)' != ''
+                  And Exists('$(CustomTransformFilePath)\$(CustomTransformFileName)')
+                  And Exists('$(PublishIntermediateOutputPath)web.config')
+                  And '$(RunXdt)' == 'true'"
+                  Source="$(PublishIntermediateOutputPath)web.config"
+                  Transform="$(CustomTransformFilePath)\$(CustomTransformFileName)"
+                  Destination="$(PublishIntermediateOutputPath)web.config"
+                  StackTrace="$(TransformXmlStackTraceEnabled)"
+                  SourceRootPath="$(PublishIntermediateOutputPath)"
+                  TransformRootPath="$(CustomTransformFilePath)"/>
+
+    <!-- Transform the environment variables in the web.config with the $(WebConfigEnvironmentVariables) from publish profiles -->
+    <ItemGroup>
+      <AllEnvTransformFiles Include="$(MSBuildThisFileDirectory)Transforms\EnvironmentNoLocation.transform;$(MSBuildThisFileDirectory)Transforms\EnvironmentWithLocation.transform;" />
+    </ItemGroup>
+    <GenerateEnvTransform Condition=" '$(WebConfigEnvironmentVariables)' != '' "
+                          WebConfigEnvironmentVariables = "$(WebConfigEnvironmentVariables)"
+                          EnvTransformTemplatePaths="@(AllEnvTransformFiles)"
+                          PublishTempDirectory="$(PublishIntermediateTempPath)">
+                          <Output TaskParameter="GeneratedTransformFullPaths" ItemName="_EnvTransformFiles" />
+    </GenerateEnvTransform>
+
+    <TransformXml Condition=" '%(_EnvTransformFiles.Identity)' != ''
+                  And Exists('%(_EnvTransformFiles.Identity)')
+                  And Exists('$(PublishIntermediateOutputPath)web.config')
+                  And '$(RunXdt)' == 'true'"
+              Source="$(PublishIntermediateOutputPath)web.config"
+              Transform="%(_EnvTransformFiles.Identity)"
+              Destination="$(PublishIntermediateOutputPath)web.config"
+              StackTrace="false"
+              SourceRootPath="$(PublishIntermediateOutputPath)"
+              TransformRootPath="$(PublishIntermediateTempPath)"
+              IgnoreError="true"/>
   </Target>
 
   <!--

--- a/src/Publish/Targets/TransformTargets/Transforms/EnvironmentNoLocation.transform
+++ b/src/Publish/Targets/TransformTargets/Transforms/EnvironmentNoLocation.transform
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+        <system.webServer>
+          <aspNetCore>
+                <environmentVariables xdt:Transform="InsertIfMissing" />
+      </aspNetCore>
+    </system.webServer>
+</configuration>

--- a/src/Publish/Targets/TransformTargets/Transforms/EnvironmentWithLocation.transform
+++ b/src/Publish/Targets/TransformTargets/Transforms/EnvironmentWithLocation.transform
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+    <location>
+        <system.webServer>
+          <aspNetCore>
+                <environmentVariables xdt:Transform="InsertIfMissing" />
+      </aspNetCore>
+    </system.webServer>
+  </location>
+</configuration>

--- a/src/Publish/Tasks/Tasks/GenerateEnvTransform.cs
+++ b/src/Publish/Tasks/Tasks/GenerateEnvTransform.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.NET.Sdk.Publish.Tasks
+{
+    public class GenerateEnvTransform : Task
+    {
+        [Required]
+        public string WebConfigEnvironmentVariables { get; set; }
+
+        [Required]
+        public string[] EnvTransformTemplatePaths { get; set; }
+
+        [Required]
+        public string PublishTempDirectory { get; set; }
+
+        [Output]
+        public string[] GeneratedTransformFullPaths { get; set; }
+
+        public override bool Execute()
+        {
+            if (string.IsNullOrEmpty(WebConfigEnvironmentVariables))
+            {
+                // Nothing to do here.
+                return true;
+            }
+
+            bool isSuccess = true;
+
+            List<string> generatedFiles = new List<string>();
+            foreach (var envTransformTemplatePath in EnvTransformTemplatePaths)
+            {
+                if (File.Exists(envTransformTemplatePath))
+                {
+                    string templateContent = File.ReadAllText(envTransformTemplatePath);
+                    XDocument templateContentDocument = XDocument.Parse(templateContent);
+
+                    XDocument envTransformDoc = GenerateEnvTransformDocument(templateContentDocument, WebConfigEnvironmentVariables);
+                    if (envTransformDoc != null)
+                    {
+                        string generatedTransformFileName = Path.Combine(PublishTempDirectory, Path.GetFileName(envTransformTemplatePath));
+                        envTransformDoc.Save(generatedTransformFileName, SaveOptions.None);
+                        generatedFiles.Add(generatedTransformFileName);
+                    }
+                }
+            }
+
+            GeneratedTransformFullPaths = generatedFiles.ToArray();
+            return isSuccess;
+        }
+
+        public XDocument GenerateEnvTransformDocument(XDocument templateContentDocument, string webConfigEnvironmentVariables)
+        {
+            if (string.IsNullOrEmpty(webConfigEnvironmentVariables))
+            {
+                return null;
+            }
+
+            if (templateContentDocument == null)
+            {
+                return null;
+            }
+
+            var envVariables = GetEnvironmentVariables(webConfigEnvironmentVariables);
+            if (envVariables == null || envVariables.Count == 0)
+            {
+                return null;
+            }
+
+            XDocument updatedContent = templateContentDocument;
+            XNamespace xdt = "http://schemas.microsoft.com/XML-Document-Transform";
+            foreach (var envVariable in envVariables)
+            {
+                var envVariableTransform =
+                        new XElement("environmentVariable", new XAttribute("name", envVariable.Key),
+                        new XAttribute("value", envVariable.Value),
+                        new XAttribute(xdt + "Locator", "Match(name)"),
+                        new XAttribute(xdt + "Transform", "InsertIfMissing"));
+
+                updatedContent.Descendants("environmentVariables").Single().Add(envVariableTransform);
+            }
+
+            return updatedContent;
+        }
+
+        public List<KeyValuePair<string, string>> GetEnvironmentVariables(string webConfigEnvironmentVariables)
+        {
+            if (string.IsNullOrEmpty(webConfigEnvironmentVariables))
+            {
+                return null;
+            }
+
+            var keyValuePairs = new List<KeyValuePair<string, string>>();
+            IEnumerable<string> envVars = webConfigEnvironmentVariables.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var envVar in envVars)
+            {
+                var keyValueArray = envVar.Split(new char[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
+
+                string name = keyValueArray.First();
+                string value = string.Join("", keyValueArray.Skip(1));
+                keyValuePairs.Add(new KeyValuePair<string, string>(keyValueArray[0], value));
+            }
+
+            return keyValuePairs;
+        }
+    }
+}

--- a/test/Publish/Tasks/Tasks/GenerateEnvTransformTests.cs
+++ b/test/Publish/Tasks/Tasks/GenerateEnvTransformTests.cs
@@ -1,0 +1,326 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.NET.Sdk.Publish.Tasks.Xdt;
+using Xunit;
+
+namespace Microsoft.NET.Sdk.Publish.Tasks.Tests.Tasks
+{
+    public class GenerateEnvTransformTests
+    {
+        private XDocument _environmentTransformWithLocationTemplate => XDocument.Parse(
+@"<?xml version=""1.0""?>
+<configuration xmlns:xdt=""http://schemas.microsoft.com/XML-Document-Transform"">
+   <location>
+     <system.webServer>
+       <aspNetCore>
+         <environmentVariables xdt:Transform = ""InsertIfMissing"" />
+          </aspNetCore>
+        </system.webServer>
+    </location>
+</configuration>");
+
+        private XDocument _environmentTransformWithoutLocationTemplate => XDocument.Parse(
+@"<?xml version=""1.0""?>
+<configuration xmlns:xdt=""http://schemas.microsoft.com/XML-Document-Transform"">
+     <system.webServer>
+       <aspNetCore>
+         <environmentVariables xdt:Transform = ""InsertIfMissing"" />
+          </aspNetCore>
+        </system.webServer>
+</configuration>");
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", null)]
+        public void GetEnvironmentVariables_HandlesNullAndEmpty(string value, object expected)
+        {
+            // Arrange
+            GenerateEnvTransform env = new GenerateEnvTransform();
+
+            // Act 
+            var envVariables = env.GetEnvironmentVariables(value);
+
+            // Assert
+            Assert.Equal(expected, envVariables);
+        }
+
+        [Fact]
+        public void GenerateEnvTransformDocument_HandlesNullAndEmpty()
+        {
+            // Arrange
+            GenerateEnvTransform env = new GenerateEnvTransform();
+
+            // Act 
+            XDocument transformDoc = env.GenerateEnvTransformDocument(null, null);
+
+            // Assert
+            Assert.Null(transformDoc);
+        }
+
+        [Theory]
+        [InlineData(null, true)]
+        [InlineData("", true)]
+        public void Execute_DoesnotFail_IfEnvVarIsNullOrEmpty(string envVariable, bool expected)
+        {
+            // Arrange
+            GenerateEnvTransform env = new GenerateEnvTransform()
+            {
+                WebConfigEnvironmentVariables = envVariable
+            };
+
+            // Act 
+            bool isSuccess = env.Execute();
+
+            // Assert
+            Assert.Equal(expected, isSuccess);
+
+        }
+
+        [Theory]
+        [InlineData("envname=envvalue", 1)]
+        [InlineData("envname=envvalue;envname2=envvalue2", 2)]
+        [InlineData("envname=", 1)]
+        [InlineData("=envname", 1)]
+        [InlineData("=envname=", 1)]
+        [InlineData("=envname=envvalue", 1)]
+        [InlineData("envnameWithoutEqual", 1)]
+        [InlineData("envname=envvalue;envname2", 2)]
+        [InlineData("envnamewithsemicolon=envvalue%3enVVal;", 1)]
+        public void GetEnvironmentVariables_Returns_CorrectValues(string value, int expectedCount)
+        {
+            // Arrange
+            GenerateEnvTransform env = new GenerateEnvTransform();
+
+            // Act 
+            var envVariables = env.GetEnvironmentVariables(value);
+
+            // Assert
+            Assert.Equal(expectedCount, envVariables.Count);
+        }
+
+        [Theory]
+        [InlineData("envname=envvalue", 1)]
+        [InlineData("envname=envvalue;envname2=envvalue2", 2)]
+        [InlineData("envname=", 1)]
+        [InlineData("=envname", 1)]
+        [InlineData("=envname=", 1)]
+        [InlineData("=envname=envvalue", 1)]
+        [InlineData("envnameWithoutEqual", 1)]
+        [InlineData("envname=envvalue;envname2", 2)]
+        [InlineData("envname=envvalue;envname2=val2;envName3=val3", 3)]
+        [InlineData("envnamewithsemicolon=envvalue%3enVVal;", 1)]
+        public void GenerateEnvTransform_GeneretesTransforms_ForAllCases(string envVariables, int expected)
+        {
+            GenerateEnvTransform env = new GenerateEnvTransform();
+            IList<XDocument> templateDocumentList = new List<XDocument>() { _environmentTransformWithLocationTemplate, _environmentTransformWithoutLocationTemplate };
+
+            foreach (var template in templateDocumentList)
+            {
+                // Act
+                XDocument envDoc = env.GenerateEnvTransformDocument(template, envVariables);
+
+                // Assert
+                Assert.Equal(expected, envDoc.Descendants("environmentVariable").Count());
+            }
+
+        }
+
+        [Theory]
+        [InlineData("envname=envvalue", 1)]
+        [InlineData("envname=envvalue;envname2=envvalue2", 2)]
+        [InlineData("envname=", 1)]
+        [InlineData("=envname", 1)]
+        [InlineData("=envname=", 1)]
+        [InlineData("=envname=envvalue", 1)]
+        [InlineData("envnameWithoutEqual", 1)]
+        [InlineData("envname=envvalue;envname2", 2)]
+        [InlineData("envname=envvalue;envname2=val2;envName3=val3", 3)]
+        [InlineData("envnamewithsemicolon=envvalue%3enVVal;", 1)]
+        public void Execute_Updates_WebConfig_Correctly(string envVariables, int expected)
+        {
+            string envTemplatePath = Path.GetTempFileName();
+            string webConfigPath = Path.GetTempFileName();
+            string tempDir = Path.GetDirectoryName(envTemplatePath);
+            try
+            {
+                // Arrange
+                List<XDocument> locationWebConfigTemplateList = new List<XDocument>() {WebConfigTransformTemplates.WebConfigTemplate};
+                foreach (var locationWebConfigTemplate in locationWebConfigTemplateList)
+                {
+
+                    _environmentTransformWithLocationTemplate.Save(envTemplatePath, SaveOptions.None);
+                    XDocument webConfigTemplate = locationWebConfigTemplate;
+                    webConfigTemplate.Save(webConfigPath);
+
+                    GenerateEnvTransform env = new GenerateEnvTransform()
+                    {
+                        WebConfigEnvironmentVariables = envVariables,
+                        EnvTransformTemplatePaths = new List<string>() { envTemplatePath }.ToArray(),
+                        PublishTempDirectory = tempDir
+                    };
+
+
+                    // Act
+                    bool isSuccess = env.Execute();
+                    Assert.True(isSuccess);
+                    foreach (var generatedPath in env.GeneratedTransformFullPaths)
+                    {
+                        Assert.True(File.Exists(generatedPath));
+
+                        TransformXml transformTask = new TransformXml()
+                        {
+                            Source = webConfigPath,
+                            Destination = webConfigPath,
+                            Transform = generatedPath,
+                            SourceRootPath = Path.GetTempPath(),
+                            TransformRootPath = Path.GetTempPath(),
+                            StackTrace = true
+                        };
+
+                        bool success = transformTask.RunXmlTransform(isLoggingEnabled: false);
+
+                        // Assert
+                        Assert.Equal(expected, XDocument.Parse(File.ReadAllText(webConfigPath)).Root.Descendants("environmentVariable").Count());
+                    }
+                }
+            }
+            finally
+            {
+                File.Delete(envTemplatePath);
+                File.Delete(webConfigPath);
+            }
+        }
+
+        [Theory]
+        [InlineData("envname=envvalue", 1)]
+        [InlineData("envname=envvalue;envname2=envvalue2", 2)]
+        [InlineData("envname=", 1)]
+        [InlineData("=envname", 1)]
+        [InlineData("=envname=", 1)]
+        [InlineData("=envname=envvalue", 1)]
+        [InlineData("envnameWithoutEqual", 1)]
+        [InlineData("envname=envvalue;envname2", 2)]
+        [InlineData("envname=envvalue;envname2=val2;envName3=val3", 3)]
+        [InlineData("envnamewithsemicolon=envvalue%3enVVal;", 1)]
+        public void EnvTransform_Updates_WebConfig_Correctly_EvenWithEnvVariable(string envVariables, int expected)
+        {
+            string envTemplatePath = Path.GetTempFileName();
+            string webConfigPath = Path.GetTempFileName();
+            string tempDir = Path.GetDirectoryName(envTemplatePath);
+            try
+            {
+                // Arrange
+                _environmentTransformWithLocationTemplate.Save(envTemplatePath, SaveOptions.None);
+                XDocument webConfigTemplate = WebConfigTransformTemplates.WebConfigTemplateWithEnvironmentVariable;
+                webConfigTemplate.Save(webConfigPath);
+
+                GenerateEnvTransform env = new GenerateEnvTransform()
+                {
+                    WebConfigEnvironmentVariables = envVariables,
+                    EnvTransformTemplatePaths = new List<string>() { envTemplatePath }.ToArray(),
+                    PublishTempDirectory = tempDir
+                };
+
+                // Act
+                bool isSuccess = env.Execute();
+                Assert.True(isSuccess);
+                foreach (var generatedPath in env.GeneratedTransformFullPaths)
+                {
+                    Assert.True(File.Exists(generatedPath));
+
+                    TransformXml transformTask = new TransformXml()
+                    {
+                        Source = webConfigPath,
+                        Destination = webConfigPath,
+                        Transform = generatedPath,
+                        SourceRootPath = Path.GetTempPath(),
+                        TransformRootPath = Path.GetTempPath(),
+                        StackTrace = true
+                    };
+
+                    bool success = transformTask.RunXmlTransform(isLoggingEnabled: false);
+
+                    // Assert
+                    // Expected should be always one more since an env variable is already present in the web.config.
+                    Assert.Equal(expected + 1, XDocument.Parse(File.ReadAllText(webConfigPath)).Root.Descendants("environmentVariable").Count());
+                }
+            }
+            finally
+            {
+                File.Delete(envTemplatePath);
+                File.Delete(webConfigPath);
+            }
+        }
+
+        [Theory]
+        [InlineData("envname=envvalue", 1)]
+        [InlineData("envname=envvalue;envname2=envvalue2", 2)]
+        [InlineData("envname=", 1)]
+        [InlineData("=envname", 1)]
+        [InlineData("=envname=", 1)]
+        [InlineData("=envname=envvalue", 1)]
+        [InlineData("envnameWithoutEqual", 1)]
+        [InlineData("envname=envvalue;envname2", 2)]
+        [InlineData("envname=envvalue;envname2=val2;envName3=val3", 3)]
+        [InlineData("envnamewithsemicolon=envvalue%3enVVal;", 1)]
+        public void Execute_Updates_WebConfig_Correctly_WithNoLocation(string envVariables, int expected)
+        {
+            string envTemplatePath = Path.GetTempFileName();
+            string webConfigPath = Path.GetTempFileName();
+            string tempDir = Path.GetDirectoryName(envTemplatePath);
+            try
+            {
+                List<XDocument> locationWebConfigTemplateList = new List<XDocument>() {WebConfigTransformTemplates.WebConfigTemplateWithoutLocation,
+                                                                               WebConfigTransformTemplates.WebConfigTemplateWithNonRelevantLocationFirst,
+                                                                               WebConfigTransformTemplates.WebConfigTemplateWithNonRelevantLocationLast,
+                                                                               WebConfigTransformTemplates.WebConfigTemplateWithRelevantLocationFirst,
+                                                                               WebConfigTransformTemplates.WebConfigTemplateWithRelevantLocationLast};
+                foreach (var locationWebConfigTemplate in locationWebConfigTemplateList)
+                {
+                    // Arrange
+                    _environmentTransformWithoutLocationTemplate.Save(envTemplatePath, SaveOptions.None);
+                    XDocument webConfigTemplate = locationWebConfigTemplate;
+                    webConfigTemplate.Save(webConfigPath);
+
+                    GenerateEnvTransform env = new GenerateEnvTransform()
+                    {
+                        WebConfigEnvironmentVariables = envVariables,
+                        EnvTransformTemplatePaths = new List<string>() { envTemplatePath }.ToArray(),
+                        PublishTempDirectory = tempDir
+                    };
+
+
+                    // Act
+                    bool isSuccess = env.Execute();
+                    Assert.True(isSuccess);
+                    foreach (var generatedPath in env.GeneratedTransformFullPaths)
+                    {
+                        Assert.True(File.Exists(generatedPath));
+
+                        TransformXml transformTask = new TransformXml()
+                        {
+                            Source = webConfigPath,
+                            Destination = webConfigPath,
+                            Transform = generatedPath,
+                            SourceRootPath = Path.GetTempPath(),
+                            TransformRootPath = Path.GetTempPath(),
+                            StackTrace = true
+                        };
+
+                        bool success = transformTask.RunXmlTransform(isLoggingEnabled: false);
+
+                        // Assert
+                        Assert.Equal(expected, XDocument.Parse(File.ReadAllText(webConfigPath)).Root.Descendants("environmentVariable").Count());
+                    }
+                }
+            }
+            finally
+            {
+                File.Delete(envTemplatePath);
+                File.Delete(webConfigPath);
+            }
+        }
+    }
+}

--- a/test/Publish/Tasks/Tasks/TransformXmlTests.cs
+++ b/test/Publish/Tasks/Tasks/TransformXmlTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Tests.Tasks
                     StackTrace = true
                 };
 
-                bool success = transformTask.RunXmlTrasform(isLoggingEnabled: false);
+                bool success = transformTask.RunXmlTransform(isLoggingEnabled: false);
 
 
                 // Assert
@@ -120,7 +120,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Tests.Tasks
                     StackTrace = true
                 };
 
-                bool success = transformTask.RunXmlTrasform(isLoggingEnabled: false);
+                bool success = transformTask.RunXmlTransform(isLoggingEnabled: false);
 
 
                 // Assert


### PR DESCRIPTION
Support for running Environment transform.

Prereq:
`    <WebConfigEnvironmentVariables>ennvvar1=envval1;envvar2=envval2;</WebConfigEnvironmentVariables>`

If the following property is set in the project file or pubxml, then these env variables will be added to the generated web.config.

The above will generate the following web.config 

```
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <location path="." inheritInChildApplications="false">
    <system.webServer>
      <handlers>
        <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
      </handlers>
      <aspNetCore processPath="dotnet" arguments=".\WebApplication166.dll" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" hostingModel="inprocess" >
        <environmentVariables>
          <environmentVariable name="ennvvar1" value="envval1"/>
          <environmentVariable name="envvar2" value="envval2"/>
        </environmentVariables>
      </aspNetCore>
    </system.webServer>
  </location>
</configuration>
```

This also handles web.config with or without the location section. Unit tests are available for both scenarios.


@davidfowl fyi 