### PR TITLE
Allow overriding WarnOnPackingNonPackableProject

### DIFF
--- a/src/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.props
+++ b/src/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.props
@@ -23,7 +23,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GenerateDependencyFile Condition="'$(GenerateDependencyFile)' == ''">true</GenerateDependencyFile>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <IsPackable Condition="'$(IsPackable)' == ''">false</IsPackable>
-    <WarnOnPackingNonPackableProject Condition="'$(IsPackable)' == 'false'">true</WarnOnPackingNonPackableProject>
+    <WarnOnPackingNonPackableProject Condition="'$(WarnOnPackingNonPackableProject)' == '' and '$(IsPackable)' == 'false'">true</WarnOnPackingNonPackableProject>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' And '$(EnableDefaultContentItems)' == 'true' ">


### PR DESCRIPTION
Follow up to https://github.com/aspnet/websdk/pull/603

We updated the aspnetcore repo to the preview 5 SDK, and our build output looks like this now. I tried using Directory.Build.props to suppress this, but it looks like the web sdk is overriding me.

![image](https://user-images.githubusercontent.com/2696087/57342082-016fa000-70f2-11e9-9839-72ac9eec71c4.png)
