### PR TITLE
Conditionally disable content support

### DIFF
--- a/src/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.props
+++ b/src/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.props
@@ -6,16 +6,16 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <DefaultItemExcludes>$(DefaultItemExcludes);**\node_modules\**;node_modules\**</DefaultItemExcludes>
-    <DefaultItemExcludes>$(DefaultItemExcludes);**\jspm_packages\**;jspm_packages\**</DefaultItemExcludes>
-    <DefaultItemExcludes>$(DefaultItemExcludes);**\bower_components\**;bower_components\**</DefaultItemExcludes>
-    <DefaultWebContentItemExcludes>$(DefaultWebContentItemExcludes);wwwroot\**</DefaultWebContentItemExcludes>
+    <DefaultItemExcludes  Condition=" '$(DisableWebSdkContent)' == '' ">$(DefaultItemExcludes);**\node_modules\**;node_modules\**</DefaultItemExcludes>
+    <DefaultItemExcludes  Condition=" '$(DisableWebSdkContent)' == '' ">$(DefaultItemExcludes);**\jspm_packages\**;jspm_packages\**</DefaultItemExcludes>
+    <DefaultItemExcludes  Condition=" '$(DisableWebSdkContent)' == '' ">$(DefaultItemExcludes);**\bower_components\**;bower_components\**</DefaultItemExcludes>
+    <DefaultWebContentItemExcludes Condition=" '$(DisableWebSdkContent)' == '' ">$(DefaultWebContentItemExcludes);wwwroot\**</DefaultWebContentItemExcludes>
 
     <OutputType>Exe</OutputType>
     <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
@@ -28,25 +28,26 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' And '$(EnableDefaultContentItems)' == 'true' ">
     <!-- Publish everything under wwwroot, all JSON files, all config files and all Razor files -->
-    <Content Include="wwwroot\**" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
-    <Content Include="**\*.config" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)" />
-    <Content Include="**\*.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)" />
+    <Content Condition=" '$(DisableWebSdkContent)' == '' " Include="wwwroot\**" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+    <Content Condition=" '$(DisableWebSdkContent)' == '' " Include="**\*.config" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)" />
+    <Content Condition=" '$(DisableWebSdkContent)' == '' " Include="**\*.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)" />
 
     <!-- Set CopyToPublishDirectory to Never for items under AppDesignerFolder ("Properties", by default) to avoid publishing launchSettings.json -->
     <Content Update="$(AppDesignerFolder)\**" CopyToPublishDirectory="Never" Condition="'$(AppDesignerFolder)' != ''"/>
-    
+
     <!-- Remove Content items from other item types (in a way that CPS understands) -->
-    <None Remove="wwwroot\**;**\*.json;**\*.config" />
-    <Compile Remove="wwwroot\**" />
-    <EmbeddedResource Remove="wwwroot\**" />
-    
+    <None Condition=" '$(DisableWebSdkContent)' == '' " Remove="wwwroot\**" />
+    <None Remove="**\*.json;**\*.config" />
+    <Compile Condition=" '$(DisableWebSdkContent)' == '' " Remove="wwwroot\**" />
+    <EmbeddedResource Condition=" '$(DisableWebSdkContent)' == '' " Remove="wwwroot\**" />
+
     <!-- Keep track of the default content items for later to distinguish them from newly generated content items -->
-    <_ContentIncludedByDefault Include="@(Content)" />
+    <_ContentIncludedByDefault Condition=" '$(DisableWebSdkContent)' == '' " Include="@(Content)" />
 
   </ItemGroup>
 
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props"
-      Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props')"/>
+      Condition=" '$(DisableWebSdkContent)' == '' And Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props')"/>
 
 </Project>
 

--- a/src/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.props
+++ b/src/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.props
@@ -12,10 +12,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <DefaultItemExcludes  Condition=" '$(DisableWebSdkContent)' == '' ">$(DefaultItemExcludes);**\node_modules\**;node_modules\**</DefaultItemExcludes>
-    <DefaultItemExcludes  Condition=" '$(DisableWebSdkContent)' == '' ">$(DefaultItemExcludes);**\jspm_packages\**;jspm_packages\**</DefaultItemExcludes>
-    <DefaultItemExcludes  Condition=" '$(DisableWebSdkContent)' == '' ">$(DefaultItemExcludes);**\bower_components\**;bower_components\**</DefaultItemExcludes>
-    <DefaultWebContentItemExcludes Condition=" '$(DisableWebSdkContent)' == '' ">$(DefaultWebContentItemExcludes);wwwroot\**</DefaultWebContentItemExcludes>
+    <DisableWebSdkContent Condition=" '$(DisableWebSdkContent)' == ''">false</DisableWebSdkContent>
+    <DefaultItemExcludes  Condition=" '$(DisableWebSdkContent)' != 'true' ">$(DefaultItemExcludes);**\node_modules\**;node_modules\**</DefaultItemExcludes>
+    <DefaultItemExcludes  Condition=" '$(DisableWebSdkContent)' != 'true' ">$(DefaultItemExcludes);**\jspm_packages\**;jspm_packages\**</DefaultItemExcludes>
+    <DefaultItemExcludes  Condition=" '$(DisableWebSdkContent)' != 'true' ">$(DefaultItemExcludes);**\bower_components\**;bower_components\**</DefaultItemExcludes>
+    <DefaultWebContentItemExcludes Condition=" '$(DisableWebSdkContent)' != 'true' ">$(DefaultWebContentItemExcludes);wwwroot\**</DefaultWebContentItemExcludes>
 
     <OutputType>Exe</OutputType>
     <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
@@ -26,28 +27,27 @@ Copyright (c) .NET Foundation. All rights reserved.
     <WarnOnPackingNonPackableProject Condition="'$(WarnOnPackingNonPackableProject)' == '' and '$(IsPackable)' == 'false'">true</WarnOnPackingNonPackableProject>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' And '$(EnableDefaultContentItems)' == 'true' ">
+  <ItemGroup Condition=" '$(DisableWebSdkContent)' != 'true' And '$(EnableDefaultItems)' == 'true' And '$(EnableDefaultContentItems)' == 'true' ">
     <!-- Publish everything under wwwroot, all JSON files, all config files and all Razor files -->
-    <Content Condition=" '$(DisableWebSdkContent)' == '' " Include="wwwroot\**" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
-    <Content Condition=" '$(DisableWebSdkContent)' == '' " Include="**\*.config" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)" />
-    <Content Condition=" '$(DisableWebSdkContent)' == '' " Include="**\*.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)" />
+    <Content Include="wwwroot\**" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+    <Content Include="**\*.config" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)" />
+    <Content Include="**\*.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)" />
 
     <!-- Set CopyToPublishDirectory to Never for items under AppDesignerFolder ("Properties", by default) to avoid publishing launchSettings.json -->
     <Content Update="$(AppDesignerFolder)\**" CopyToPublishDirectory="Never" Condition="'$(AppDesignerFolder)' != ''"/>
 
     <!-- Remove Content items from other item types (in a way that CPS understands) -->
-    <None Condition=" '$(DisableWebSdkContent)' == '' " Remove="wwwroot\**" />
-    <None Remove="**\*.json;**\*.config" />
-    <Compile Condition=" '$(DisableWebSdkContent)' == '' " Remove="wwwroot\**" />
-    <EmbeddedResource Condition=" '$(DisableWebSdkContent)' == '' " Remove="wwwroot\**" />
+    <None Remove="wwwroot\**;**\*.json;**\*.config" />
+    <Compile Remove="wwwroot\**" />
+    <EmbeddedResource Remove="wwwroot\**" />
 
     <!-- Keep track of the default content items for later to distinguish them from newly generated content items -->
-    <_ContentIncludedByDefault Condition=" '$(DisableWebSdkContent)' == '' " Include="@(Content)" />
+    <_ContentIncludedByDefault Include="@(Content)" />
 
   </ItemGroup>
 
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props"
-      Condition=" '$(DisableWebSdkContent)' == '' And Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props')"/>
+      Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props')"/>
 
 </Project>
 

--- a/src/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
+++ b/src/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
@@ -12,13 +12,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.targets"
-          Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.targets') AND '$(EnableTypeScriptNuGetTarget)' != 'true'"/>
+          Condition=" '$(DisableWebSdkContent)' == '' And Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.targets') AND '$(EnableTypeScriptNuGetTarget)' != 'true'"/>
 
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.DotNetCore.targets"
-          Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.DotNetCore.targets') AND '$(EnableTypeScriptNuGetTarget)' != 'true'"/>
+          Condition=" '$(DisableWebSdkContent)' == '' And Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.DotNetCore.targets') AND '$(EnableTypeScriptNuGetTarget)' != 'true'"/>
 
   <PropertyGroup>
-    <EnableDefaultContentItems Condition=" '$(EnableDefaultContentItems)' == '' ">true</EnableDefaultContentItems>
+    <EnableDefaultContentItems Condition=" '$(DisableWebSdkContent)' == '' And '$(EnableDefaultContentItems)' == '' ">true</EnableDefaultContentItems>
     <RunWorkingDirectory Condition=" '$(RunWorkingDirectory)' == '' and '$(EnableDefaultRunWorkingDirectory)' != 'false' ">$(MSBuildProjectDirectory)</RunWorkingDirectory>
     <MSBuildWebTargetsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed.Web\</MSBuildWebTargetsPath>
     <AspNetCoreHostingModel Condition="'$(AspNetCoreHostingModel)' == '' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' != '' And '$(_TargetFrameworkVersionWithoutV)' &gt;= '3.0' ">inprocess</AspNetCoreHostingModel>

--- a/src/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
+++ b/src/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
@@ -12,13 +12,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.targets"
-          Condition=" '$(DisableWebSdkContent)' == '' And Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.targets') AND '$(EnableTypeScriptNuGetTarget)' != 'true'"/>
+          Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.targets') AND '$(EnableTypeScriptNuGetTarget)' != 'true'"/>
 
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.DotNetCore.targets"
-          Condition=" '$(DisableWebSdkContent)' == '' And Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.DotNetCore.targets') AND '$(EnableTypeScriptNuGetTarget)' != 'true'"/>
+          Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.DotNetCore.targets') AND '$(EnableTypeScriptNuGetTarget)' != 'true'"/>
 
   <PropertyGroup>
-    <EnableDefaultContentItems Condition=" '$(DisableWebSdkContent)' == '' And '$(EnableDefaultContentItems)' == '' ">true</EnableDefaultContentItems>
+    <EnableDefaultContentItems Condition=" '$(DisableWebSdkContent)' != 'true' And '$(EnableDefaultContentItems)' == '' ">true</EnableDefaultContentItems>
     <RunWorkingDirectory Condition=" '$(RunWorkingDirectory)' == '' and '$(EnableDefaultRunWorkingDirectory)' != 'false' ">$(MSBuildProjectDirectory)</RunWorkingDirectory>
     <MSBuildWebTargetsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed.Web\</MSBuildWebTargetsPath>
     <AspNetCoreHostingModel Condition="'$(AspNetCoreHostingModel)' == '' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' != '' And '$(_TargetFrameworkVersionWithoutV)' &gt;= '3.0' ">inprocess</AspNetCoreHostingModel>


### PR DESCRIPTION
Associated PR in the aspnetcore-tooling repo
https://github.com/aspnet/AspNetCore-Tooling/pull/589

This implements what we spoke about on Monday. We are conditionally disabling the content here before completely removing it in a following PR once we have validated that the move to the Razor SDK is correct.

On the Razor side we've put the things that are needed into separate files that could potentially be imported in the future by the Web SDK and added a property to detect so.