### PR TITLE
Add WebPublishProfileFile to GlobalPropertiesToRemove for ProjectReferences…

### DIFF
--- a/src/Publish/Targets/Microsoft.NET.Sdk.Publish.targets
+++ b/src/Publish/Targets/Microsoft.NET.Sdk.Publish.targets
@@ -147,6 +147,19 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </CorePublishDependsOn>
   </PropertyGroup>
 
+  <!--
+  ***********************************************************************************************
+  NOTE: We have to add WebPublishProfileFile to GlobalPropertiesToRemove to prevent it to flow to
+  other web apps that are referenced by current web app. If we don't do that, their output paths 
+  will be messed up with RuntimeIdentifier we pass in pubxml file.
+  ***********************************************************************************************
+  -->
+  <ItemDefinitionGroup>
+    <ProjectReference>
+      <GlobalPropertiesToRemove>%(GlobalPropertiesToRemove);WebPublishProfileFile</GlobalPropertiesToRemove>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+
   <Target Name="CorePublish" 
           DependsOnTargets="$(CorePublishDependsOn)"/>
   


### PR DESCRIPTION
Add WebPublishProfileFile to GlobalPropertiesToRemove for ProjectReferences to prevent flowing publish properties from pubxml to P2Ps during publish