### PR TITLE
Add component analyzers to the WebSDK.

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="3.0.0-preview8.19358.6">
+      <Uri>https://github.com/aspnet/AspNetCore</Uri>
+      <Sha>59d636f6bde6104121a19e4e0229a76bb46b8ab1</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Mvc.Analyzers" Version="3.0.0-preview8.19358.6">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>
       <Sha>59d636f6bde6104121a19e4e0229a76bb46b8ab1</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -43,6 +43,7 @@
 
   -->
   <PropertyGroup Label="Automated">
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>3.0.0-preview8.19358.6</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
     <MicrosoftAspNetCoreMvcAnalyzersPackageVersion>3.0.0-preview8.19358.6</MicrosoftAspNetCoreMvcAnalyzersPackageVersion>
     <MicrosoftAspNetCoreMvcApiAnalyzersPackageVersion>3.0.0-preview8.19358.6</MicrosoftAspNetCoreMvcApiAnalyzersPackageVersion>
   </PropertyGroup>

--- a/src/Web/Package/Microsoft.NET.Sdk.Web.csproj
+++ b/src/Web/Package/Microsoft.NET.Sdk.Web.csproj
@@ -29,6 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.Analyzers" Version="$(MicrosoftAspNetCoreComponentsAnalyzersPackageVersion)" PrivateAssets="All" BundleAsAnalyzer="true" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Analyzers" Version="$(MicrosoftAspNetCoreMvcAnalyzersPackageVersion)" PrivateAssets="All" BundleAsAnalyzer="true" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Api.Analyzers" Version="$(MicrosoftAspNetCoreMvcApiAnalyzersPackageVersion)" PrivateAssets="All" BundleAsAnalyzer="true" />
   </ItemGroup>

--- a/src/Web/Sdk/Sdk.props
+++ b/src/Web/Sdk/Sdk.props
@@ -47,4 +47,11 @@ Copyright (c) .NET Foundation. All rights reserved.
       IsImplicitlyDefined="true" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(DisableImplicitComponentsAnalyzers)' != 'true' And '$(DisableImplicitAspNetCoreAnalyzers)' != 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">
+    <Analyzer
+      Include="$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)..))\analyzers\cs\Microsoft.AspNetCore.Components.Analyzers.dll"
+      Condition="'$(Language)'=='C#'"
+      IsImplicitlyDefined="true" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
- We obey two flags when enabling the component analyzers.
  1. `DisableImplicitComponentAnalyzers` (DICA)
  2. `DisableImplicitAspNetCoreAnalyzers` (DIAA)

The way those flags impact component analyzers are as follows:

| DICA    | DIAA    | Action                                                                                                     |
|---------|---------|------------------------------------------------------------------------------------------------------------|
| `true`  | `true`  | No component analyzers added from SDK |
| `true`  | `false` | No component analyzers added from SDK                                                                      |
| `false` | `true`  | No component analyzers added from SDK                                                                      |
| `false` | `false` | Component analyzers added in SDK                                                                           |

aspnet/AspNetCore#8825

@vijayrkn what's the best way to locally test a change like this where we're adding new analyzers and adding a mechanism to enable/disable them? Also, Is this all that's needed to add the analyzer to the sdk or is there somewhere else / some other repo I need to update to include the components analyzer in the SDK?