### PR TITLE
Adds Microsoft.AspNetCore.Analyzers package

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
+    <Dependency Name="Microsoft.AspNetCore.Analyzers" Version="3.0.0-preview8.19366.10">
+      <Uri>https://github.com/aspnet/AspNetCore</Uri>
+      <Sha>4ba66f05bf2ff20e38ae00d3ab27256df778a652</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="3.0.0-preview8.19366.10">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>
       <Sha>4ba66f05bf2ff20e38ae00d3ab27256df778a652</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,6 +17,7 @@
     <SystemSecurityCryptographyProtectedDataPackageVersion>4.3.0</SystemSecurityCryptographyProtectedDataPackageVersion>
     <SystemCollectionsSpecializedPackageVersion>4.3.0</SystemCollectionsSpecializedPackageVersion>
     <SystemXmlXmlDocumentPackageVersion>4.3.0</SystemXmlXmlDocumentPackageVersion>
+    <MicrosoftAspNetCoreAnalyzersPackageVersion>3.0.0-preview8.19366.10</MicrosoftAspNetCoreAnalyzersPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <VersionPrefix>3.0.100</VersionPrefix>

--- a/src/Web/Package/Microsoft.NET.Sdk.Web.csproj
+++ b/src/Web/Package/Microsoft.NET.Sdk.Web.csproj
@@ -29,6 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Analyzers" Version="$(MicrosoftAspNetCoreAnalyzersPackageVersion)" PrivateAssets="All" BundleAsAnalyzer="true" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Analyzers" Version="$(MicrosoftAspNetCoreComponentsAnalyzersPackageVersion)" PrivateAssets="All" BundleAsAnalyzer="true" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Analyzers" Version="$(MicrosoftAspNetCoreMvcAnalyzersPackageVersion)" PrivateAssets="All" BundleAsAnalyzer="true" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Api.Analyzers" Version="$(MicrosoftAspNetCoreMvcApiAnalyzersPackageVersion)" PrivateAssets="All" BundleAsAnalyzer="true" />

--- a/src/Web/Sdk/Sdk.props
+++ b/src/Web/Sdk/Sdk.props
@@ -37,6 +37,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <ItemGroup Condition="'$(DisableImplicitAspNetCoreAnalyzers)' != 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">
     <Analyzer
+      Include="$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)..))\analyzers\cs\Microsoft.AspNetCore.Analyzers.dll"
+      Condition="'$(Language)'=='C#'"
+      IsImplicitlyDefined="true" />
+    <Analyzer
       Include="$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)..))\analyzers\cs\Microsoft.AspNetCore.Mvc.Analyzers.dll"
       Condition="'$(Language)'=='C#'"
       IsImplicitlyDefined="true" />


### PR DESCRIPTION
This is another implicit analyzer package that follows the same rules as
the MVC analyzer package for when it's included.

We want this to be a different package to reflect the correct branding -
so that users aren't confused about the UI or `.ruleset` file shows

Part of: https://github.com/aspnet/AspNetCore/issues/12288