### PR TITLE
Fix default None items not being removed from Content items

### DIFF
--- a/src/Worker/Targets/Microsoft.NET.Sdk.Worker.props
+++ b/src/Worker/Targets/Microsoft.NET.Sdk.Worker.props
@@ -27,6 +27,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Set CopyToOutputDirectory and CopyToPublishDirectory to Never for items under AppDesignerFolder ("Properties", by default) to avoid publishing launchSettings.json -->
     <Content Update="$(AppDesignerFolder)\**" CopyToOutputDirectory="Never" CopyToPublishDirectory="Never" Condition="'$(AppDesignerFolder)' != ''"/>
 
+    <!-- Remove Content items from other item types -->
+    <None Remove="**\*.json;**\*.config" />
+
     <!-- Keep track of the default content items for later to distinguish them from newly generated content items -->
     <_ContentIncludedByDefault Include="@(Content)" />
 


### PR DESCRIPTION
The worker sdk props adds Content items for .json and .config files
but does not remove the corresponding None items.

This was causing Visual Studio for Mac to show duplicate files. This
also mirrors what the web sdk and the razor sdk do in their .props
files.

// cc @sayedihashimi