### PR TITLE
Move dotnet-tools -> dotnet-eng

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,14 +2,11 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="arcade" value="https://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
-    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="myget-dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="myget-msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
     <add key="myget-dotnet-web" value="https://dotnet.myget.org/F/dotnet-web/api/v3/index.json" />
     <add key="myget-nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
-    <add key="aspnet-aspnetcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
The dotnet-tools feed is being moved to dotnet-eng so that dotnet-tools can be used for actual tools.

https://github.com/dotnet/arcade/issues/4197