### PR TITLE
[release/3.0.1xx] Mark websdk packages as non-shipping (#1101)

### DIFF
--- a/src/ProjectSystem/Package/Microsoft.NET.Sdk.Web.ProjectSystem.csproj
+++ b/src/ProjectSystem/Package/Microsoft.NET.Sdk.Web.ProjectSystem.csproj
@@ -9,6 +9,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
+    <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Publish/Package/Microsoft.NET.Sdk.Publish.csproj
+++ b/src/Publish/Package/Microsoft.NET.Sdk.Publish.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RuntimeIdenfier Condition="'$(RuntimeIdenfier)' == ''">win7-x86</RuntimeIdenfier>
     <IsPackable>true</IsPackable>
+    <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Web/Package/Microsoft.NET.Sdk.Web.csproj
+++ b/src/Web/Package/Microsoft.NET.Sdk.Web.csproj
@@ -9,6 +9,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
+    <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Worker/Package/Microsoft.NET.Sdk.Worker.csproj
+++ b/src/Worker/Package/Microsoft.NET.Sdk.Worker.csproj
@@ -9,6 +9,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
+    <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Mark websdk packages as non-shipping
* Use IsShippingPackage

Ported from 3.1.1.xx