### PR TITLE
Use newer feeds in nuget.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -5,14 +5,13 @@
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <add key="darc-pub-dotnet-aspnetcore-c3acdca-2" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-c3acdcac-2/nuget/v3/index.json" />
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
-    <add key="arcade" value="https://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
-    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
+    <add key="dotnet3.1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json" />
+    <add key="dotnet3.1-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="myget-dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="myget-msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
     <add key="myget-dotnet-web" value="https://dotnet.myget.org/F/dotnet-web/api/v3/index.json" />
     <add key="myget-nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
-    <add key="aspnet-aspnetcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Resets nuget.config to be the same as in 3.1.1xx: https://github.com/aspnet/websdk/blob/release/3.1.1xx/NuGet.config. Main improvement is using the `dotnet3.1` and `dotnet3.1-transport` feeds. I already did this on the internal side in 3.1.2xx to unblock the build there.

CC @vijayrkn @mmitche 