### PR TITLE
Switch to 1ES servicing pools on release/3.1.4xx

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,8 +48,8 @@ stages:
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
             name: Hosted VS2017
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            name: NetCoreInternal-Pool
-            queue: buildpool.windows.10.amd64.vs2017
+            name: NetCore1ESPool-Svc-Internal
+            demands: ImageOverride -equals build.windows.10.amd64.vs2017
 
         variables:
         - _Script: eng\common\cibuild.cmd


### PR DESCRIPTION
Same as https://github.com/dotnet/websdk/pull/1671 but for `release/3.1.4xx`.

cc/ @ulisesh @lpatalas 